### PR TITLE
Allow to use multiple separators for making links to search results.

### DIFF
--- a/app/org/nlp4l/framework/builtin/StandardSolrSearch.scala
+++ b/app/org/nlp4l/framework/builtin/StandardSolrSearch.scala
@@ -40,8 +40,28 @@ class StandardSolrSearchCellAttribute(val searchOn: String, collection: String, 
       }
     }
 
-    val replaceMap = (queries zip links).toMap
-    val replaced = replaceMap.foldLeft(cell.toString){ case (s, (q, l)) => s.replaceAll(q, l) }
+    val replaceMap = queries zip links
+    val replaced = embedLinks(replaceMap, cell.toString)
     replaced
+  }
+
+  private def embedLinks(replaceMap: Seq[(String, String)], record: String): String = {
+    def loop(str: String, res: String): String = {
+      println(str)
+      if (str.isEmpty) res
+      else {
+        // find all candidates to replace and sort by term length
+        val candidates = replaceMap.filter{ case (q, l) => str.startsWith(q)}.sortBy(_._1.length)(Ordering.Int.reverse)
+        if (candidates.nonEmpty) {
+          // replace matched substring with the longest candidate
+          val replace = candidates(0)
+          loop(str.substring(replace._1.length), res + replace._2)
+        } else {
+          loop(str.substring(1), res + str(0))
+        }
+      }
+    }
+
+    loop(record, "")
   }
 }

--- a/app/org/nlp4l/framework/builtin/StandardSolrSearch.scala
+++ b/app/org/nlp4l/framework/builtin/StandardSolrSearch.scala
@@ -40,7 +40,8 @@ class StandardSolrSearchCellAttribute(val searchOn: String, collection: String, 
       }
     }
 
-    val separator = separatedBy.getOrElse("")
-    links.mkString(s"$separator ")
+    val replaceMap = (queries zip links).toMap
+    val replaced = replaceMap.foldLeft(cell.toString){ case (s, (q, l)) => s.replaceAll(q, l) }
+    replaced
   }
 }


### PR DESCRIPTION
Currently, StandardSolrSearch allows one separator to separate a record to queries. Synonyms file should be separated by two separators ("," and "=>"), so we need to allow multiple separators.

To implement that, I do
Specify a regex in "separatedBy" attribute as below to split records by multiple separators.

```
dictionary : [ 
    { 
      class : org.nlp4l.framework.builtin.TextRecordsDictionaryAttributeFactory 
      settings : { 
        cellName: synonyms 
        searchOnSolr: "http://localhost:8983/solr" 
        collection: "collection1" 
        idField: "id" 
        separatedBy: "(,)|(=>)" 
      } 
    } 
``` 

And modify source codes to create links from each query term to search results. (this PR)

With this patch, for example,this synonym record is separated into three words -- "マック", "マクド", "マクドナルド"  -- and three links for search results are created.

```
"マック, マクド => マクドナルド"
```