### PR TITLE
Add test cases for StandardSolrSearch.

### DIFF
--- a/app/org/nlp4l/framework/builtin/StandardSolrSearch.scala
+++ b/app/org/nlp4l/framework/builtin/StandardSolrSearch.scala
@@ -47,7 +47,6 @@ class StandardSolrSearchCellAttribute(val searchOn: String, collection: String, 
 
   private def embedLinks(replaceMap: Seq[(String, String)], record: String): String = {
     def loop(str: String, res: String): String = {
-      println(str)
       if (str.isEmpty) res
       else {
         // find all candidates to replace and sort by term length

--- a/test/org/nlp4l/framework/builtin/StandardSolrSearchSpec.scala
+++ b/test/org/nlp4l/framework/builtin/StandardSolrSearchSpec.scala
@@ -1,0 +1,61 @@
+package org.nlp4l.framework.builtin
+
+import java.net.URLEncoder
+
+import org.nlp4l.framework.models.CellType
+import org.specs2.mock.Mockito
+import org.specs2.mutable.Specification
+
+class StandardSolrSearchSpec extends Specification with Mockito {
+
+  val searchOn = "http://localhost:8983/solr"
+  def cellAtt(separatedBy: String, hlField: String = null) = new StandardSolrSearchCellAttribute(searchOn, "collection1", "id", hlField, Some(separatedBy), "cell1", CellType.StringType, true, false)
+
+  "StandardSolrSearchCellAttribute" should {
+    "format cell value with a separator" in {
+      val mockCell = mock[Any]
+      mockCell.toString() returns "マック,マクド,マクドナルド"
+
+      val expected =
+        List(
+          s"""<a href="/search/solr/${URLEncoder.encode(searchOn, "UTF-8")}/collection1/${URLEncoder.encode("マック", "UTF-8")}?id=id">マック</a>""",
+          s"""<a href="/search/solr/${URLEncoder.encode(searchOn, "UTF-8")}/collection1/${URLEncoder.encode("マクド", "UTF-8")}?id=id">マクド</a>""",
+          s"""<a href="/search/solr/${URLEncoder.encode(searchOn, "UTF-8")}/collection1/${URLEncoder.encode("マクドナルド", "UTF-8")}?id=id">マクドナルド</a>"""
+        ).mkString(",")
+      cellAtt(",").format(mockCell) mustEqual expected
+    }
+
+    "format cell value with multiple separators" in {
+      val mockCell = mock[Any]
+      mockCell.toString() returns "マック,マクド => マクドナルド"
+
+      val expected =
+        List(
+          s"""<a href="/search/solr/${URLEncoder.encode(searchOn, "UTF-8")}/collection1/${URLEncoder.encode("マック", "UTF-8")}?id=id">マック</a>""",
+          s"""<a href="/search/solr/${URLEncoder.encode(searchOn, "UTF-8")}/collection1/${URLEncoder.encode("マクド", "UTF-8")}?id=id">マクド</a>"""
+        ).mkString(",") +
+          " => " + s"""<a href="/search/solr/${URLEncoder.encode(searchOn, "UTF-8")}/collection1/${URLEncoder.encode("マクドナルド", "UTF-8")}?id=id">マクドナルド</a>"""
+      cellAtt("(,)|(=>)").format(mockCell) mustEqual expected
+    }
+
+    "return empty string when cell value is empty" in {
+      val mockCell = mock[Any]
+      mockCell.toString() returns ""
+      cellAtt(",").format(mockCell) mustEqual ""
+    }
+
+    "format cell value with highlight" in {
+      val mockCell = mock[Any]
+      mockCell.toString() returns "マック,マクド,マクドナルド"
+
+      val expected =
+        List(
+          s"""<a href="/search/solr/${URLEncoder.encode(searchOn, "UTF-8")}/collection1/${URLEncoder.encode("マック", "UTF-8")}?id=id&hl=body">マック</a>""",
+          s"""<a href="/search/solr/${URLEncoder.encode(searchOn, "UTF-8")}/collection1/${URLEncoder.encode("マクド", "UTF-8")}?id=id&hl=body">マクド</a>""",
+          s"""<a href="/search/solr/${URLEncoder.encode(searchOn, "UTF-8")}/collection1/${URLEncoder.encode("マクドナルド", "UTF-8")}?id=id&hl=body">マクドナルド</a>"""
+        ).mkString(",")
+      cellAtt(",", "body").format(mockCell) mustEqual expected
+    }
+
+  }
+}


### PR DESCRIPTION
I add unit tests (Specification) for StandardSolrSearchCellAttribute class.

FYI: Specs2 test framework have builtin Mockit support (https://etorreborre.github.io/specs2/guide/SPECS2-3.7/org.specs2.guide.UseMockito.html). So we can easily create tests with mock objects as I've used in the spec.

What's Mockit: http://mockito.org/