### PR TITLE
Update Dispatch vertion to 0.11.3.

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -28,7 +28,7 @@ libraryDependencies ++= Seq(
   "com.github.tototoshi" %% "slick-joda-mapper" % "2.1.0",
   "joda-time" % "joda-time" % "2.7",
   "org.joda" % "joda-convert" % "1.7",
-  "net.databinder.dispatch" %% "dispatch-core" % "0.11.2"
+  "net.databinder.dispatch" %% "dispatch-core" % "0.11.3"
 )
 
 


### PR DESCRIPTION
When I run `sbt test`, an error occured. (show stacktraces below.)

```
java.lang.NoSuchMethodError: com.ning.http.client.RequestBuilder.addQueryParameter(Ljava/lang/String;Ljava/lang/String;)Lcom/ning/http/client/RequestBuilder;]
	at play.api.http.HttpErrorHandlerExceptions$.throwableToUsefulException(HttpErrorHandler.scala:261) ~[com.typesafe.play.play_2.11-2.4.3.jar:2.4.3]
	at play.api.http.DefaultHttpErrorHandler.onServerError(HttpErrorHandler.scala:191) ~[com.typesafe.play.play_2.11-2.4.3.jar:2.4.3]
	at play.api.GlobalSettings$class.onError(GlobalSettings.scala:179) [com.typesafe.play.play_2.11-2.4.3.jar:2.4.3]
	at play.api.DefaultGlobal$.onError(GlobalSettings.scala:212) [com.typesafe.play.play_2.11-2.4.3.jar:2.4.3]
	at play.api.http.GlobalSettingsHttpErrorHandler.onServerError(HttpErrorHandler.scala:94) [com.typesafe.play.play_2.11-2.4.3.jar:2.4.3]
	at play.core.server.netty.PlayDefaultUpstreamHandler$$anonfun$9$$anonfun$apply$1.applyOrElse(PlayDefaultUpstreamHandler.scala:158) [com.typesafe.play.play-netty-server_2.11-2.4.3.jar:2.4.3]
	at play.core.server.netty.PlayDefaultUpstreamHandler$$anonfun$9$$anonfun$apply$1.applyOrElse(PlayDefaultUpstreamHandler.scala:155) [com.typesafe.play.play-netty-server_2.11-2.4.3.jar:2.4.3]
	at scala.runtime.AbstractPartialFunction.apply(AbstractPartialFunction.scala:36) [org.scala-lang.scala-library-2.11.7.jar:na]
	at scala.util.Failure$$anonfun$recover$1.apply(Try.scala:216) [org.scala-lang.scala-library-2.11.7.jar:na]
	at scala.util.Try$.apply(Try.scala:192) [org.scala-lang.scala-library-2.11.7.jar:na]
...
```

It seems library version conflict with Dispatch and others. Can be solved by updating Dispatch version.