### PR TITLE
Add trim to sample csv processor

### DIFF
--- a/app/org/nlp4l/sample/SampleCsvImportProcessor.scala
+++ b/app/org/nlp4l/sample/SampleCsvImportProcessor.scala
@@ -41,7 +41,7 @@ class SampleCsvImportProcessorFactory(settings: Config) extends ProcessorFactory
 class SampleCsvImportProcessor(val file: String, val encoding: String, val fields: Seq[String]) extends Processor {
 
   override def execute(data: Option[Dictionary]): Option[Dictionary] = {
-    val parser: CSVParser = CSVParser.parse(new File(file), Charset.forName(encoding), CSVFormat.DEFAULT.withHeader(fields: _*))
+    val parser: CSVParser = CSVParser.parse(new File(file), Charset.forName(encoding), CSVFormat.DEFAULT.withHeader(fields: _*).withTrim())
     try {
       val dict = Dictionary(
         parser.getRecords().map(
@@ -76,7 +76,7 @@ class SampleCsvDataProcessor(val fields: Seq[String], val data: Seq[String]) ext
       b.append(d)
       b.append(Properties.lineSeparator)
     })
-    val parser: CSVParser = CSVParser.parse(b.toString, CSVFormat.DEFAULT.withHeader(fields: _*))
+    val parser: CSVParser = CSVParser.parse(b.toString, CSVFormat.DEFAULT.withHeader(fields: _*).withTrim())
     try {
       val dict = Dictionary(
         parser.getRecords().map(

--- a/build.sbt
+++ b/build.sbt
@@ -22,7 +22,7 @@ libraryDependencies ++= Seq(
   "org.apache.lucene" % "lucene-backward-codecs" % "5.4.1",
   "org.apache.solr" % "solr-solrj" % "5.4.1",
   "org.apache.opennlp" % "opennlp-tools" % "1.6.0",
-  "org.apache.commons" % "commons-csv" % "1.1",
+  "org.apache.commons" % "commons-csv" % "1.4",
   "com.jsuereth" %% "scala-arm" % "1.4",
   "org.webjars" %% "webjars-play" % "2.4.0-1",
   "org.webjars" % "bootstrap" % "3.3.5",

--- a/examples/example-opennlp-ner.conf
+++ b/examples/example-opennlp-ner.conf
@@ -17,16 +17,35 @@
   ]
 
   processors : [
+//    {
+//      class : org.nlp4l.sample.SampleCsvImportProcessorFactory
+//      settings : {
+//        file:     "/tmp/ner-input-data.csv"
+//        encoding: "UTF-8"
+//        fields: [
+//          "docId",
+//          "category",
+//          "title",
+//          "body"
+//        ]
+//      }
+//    }
+
+    // Take it easy,
+    // We have another simple one to make our lives easier.
     {
-      class : org.nlp4l.sample.SampleCsvImportProcessorFactory
+      class : org.nlp4l.sample.SampleCsvDataProcessorFactory
       settings : {
-        file:     "/tmp/ner-input-data.csv"
-        encoding: "UTF-8"
         fields: [
           "docId",
           "category",
           "title",
           "body"
+        ],
+        data: [
+          "DOC-001, Sports, Washington Nationals News, The Washington Nationals have released right-handed pitcher Mitch Lively."
+          "DOC-002, Sports, Today's New York Mets,     Chris Heston who no hit the New York Mets on June 9th."
+          "DOC-003, Sports, Mark Warburton wants ...,  Mark Warburton wants to make veteran midfielder John Eustace the next captain of Rangers."
         ]
       }
     }


### PR DESCRIPTION
Hi

I have changed the code to call trim on a parsed each string in the sample CSV processors.
'withTrim()' method is used, which requires Apache commons-csv 1.3 or above,
so common-csv 1.4 is specified in build.sbt.

Also, I have changed to use SampleCsvDataProcessor instead of SampleCsvImportProcessor in the example-opennlp-ner.conf file. This would make a bit easier to understand this sample. 

Thanks
