### PR TITLE
Add more algorithm to the document classification processors

### DIFF
--- a/app/org/nlp4l/framework/builtin/spark/mllib/ClassificationProcessor.scala
+++ b/app/org/nlp4l/framework/builtin/spark/mllib/ClassificationProcessor.scala
@@ -69,11 +69,17 @@ class ClassificationProcessor(val workingDir: String,
     try {
       // Load model
       val model = algorithm match {
+        case AlgorithmSupport.NaiveBayes => {
+          NaiveBayesModelSupport.load(sc, settings.MODEL_FILE_DIR)
+        }
         case AlgorithmSupport.LogisticRegressionWithLBFGS => {
           LogisticRegressionModelSupport.load(sc, settings.MODEL_FILE_DIR)
         }
-        case AlgorithmSupport.NaiveBayes => {
-          NaiveBayesModelSupport.load(sc, settings.MODEL_FILE_DIR)
+        case AlgorithmSupport.DecisionTree => {
+          DecisionTreeModelSupport.load(sc, settings.MODEL_FILE_DIR)
+        }
+        case AlgorithmSupport.RandomForest => {
+          RandomForestModelSupport.load(sc, settings.MODEL_FILE_DIR)
         }
         case _ => throw new IllegalArgumentException("unknown algorithm: " + algorithm)
       }

--- a/app/org/nlp4l/framework/builtin/spark/mllib/CommonProcessor.scala
+++ b/app/org/nlp4l/framework/builtin/spark/mllib/CommonProcessor.scala
@@ -229,15 +229,31 @@ class WorkingDirSettings(workingDir: String) {
 }
 
 object AlgorithmSupport {
-  val LogisticRegressionWithLBFGS = "LogisticRegressionWithLBFGS"
   val NaiveBayes = "NaiveBayes"
+  val LogisticRegressionWithLBFGS = "LogisticRegressionWithLBFGS"
+  val DecisionTree = "DecisionTree"
+  val RandomForest = "RandomForest"
 
-  val Default = LogisticRegressionWithLBFGS
+  val Default = NaiveBayes
 }
 
 abstract class ModelSupport() extends Serializable  {
   def predict(testData: Vector): Double
   def save(sc: SparkContext, path: String): Unit
+}
+
+class NaiveBayesModelSupport(model: NaiveBayesModel) extends ModelSupport {
+  override def predict(features: Vector): Double = {
+    model.predict(features)
+  }
+  override def save(sc: SparkContext, path: String): Unit = {
+    model.save(sc, path)
+  }
+}
+object NaiveBayesModelSupport {
+  def load(sc: SparkContext, path: String): NaiveBayesModelSupport = {
+    new NaiveBayesModelSupport(NaiveBayesModel.load(sc, path))
+  }
 }
 
 class LogisticRegressionModelSupport(model: LogisticRegressionModel) extends ModelSupport {
@@ -254,7 +270,7 @@ object LogisticRegressionModelSupport {
   }
 }
 
-class NaiveBayesModelSupport(model: NaiveBayesModel) extends ModelSupport {
+class DecisionTreeModelSupport(model: DecisionTreeModel) extends ModelSupport {
   override def predict(features: Vector): Double = {
     model.predict(features)
   }
@@ -262,10 +278,25 @@ class NaiveBayesModelSupport(model: NaiveBayesModel) extends ModelSupport {
     model.save(sc, path)
   }
 }
-object NaiveBayesModelSupport {
-  def load(sc: SparkContext, path: String): NaiveBayesModelSupport = {
-    new NaiveBayesModelSupport(NaiveBayesModel.load(sc, path))
+object DecisionTreeModelSupport {
+  def load(sc: SparkContext, path: String): DecisionTreeModelSupport = {
+    new DecisionTreeModelSupport(DecisionTreeModel.load(sc, path))
   }
 }
+
+class RandomForestModelSupport(model: RandomForestModel) extends ModelSupport {
+  override def predict(features: Vector): Double = {
+    model.predict(features)
+  }
+  override def save(sc: SparkContext, path: String): Unit = {
+    model.save(sc, path)
+  }
+}
+object RandomForestModelSupport {
+  def load(sc: SparkContext, path: String): RandomForestModelSupport = {
+    new RandomForestModelSupport(RandomForestModel.load(sc, path))
+  }
+}
+
 
 

--- a/app/org/nlp4l/framework/builtin/spark/mllib/TrainAndModelProcessor.scala
+++ b/app/org/nlp4l/framework/builtin/spark/mllib/TrainAndModelProcessor.scala
@@ -73,7 +73,7 @@ class TrainAndModelProcessor(val workingDir: String,
       // Run training algorithm to build the model
       val model: ModelSupport = algorithm match {
         case AlgorithmSupport.NaiveBayes => {
-          val lambda = getAlgorithmParamAsDouble("lamda", 1.0)
+          val lambda = getAlgorithmParamAsDouble("lambda", 1.0)
           val modelType = getAlgorithmParam("modelType", "multinomial")
           logger.info("algorithm: " + AlgorithmSupport.NaiveBayes + ", lambda: " + lambda + ", modelType: " + modelType)
           new NaiveBayesModelSupport(

--- a/app/org/nlp4l/framework/builtin/spark/mllib/TrainAndModelProcessor.scala
+++ b/app/org/nlp4l/framework/builtin/spark/mllib/TrainAndModelProcessor.scala
@@ -17,7 +17,7 @@
 package org.nlp4l.framework.builtin.spark.mllib
 
 import com.typesafe.config.Config
-import org.apache.spark.mllib.classification.{LogisticRegressionWithLBFGS, NaiveBayes, NaiveBayesModel}
+import org.apache.spark.mllib.classification.{LogisticRegressionWithLBFGS, NaiveBayes}
 import org.apache.spark.mllib.evaluation.MulticlassMetrics
 import org.apache.spark.mllib.regression.LabeledPoint
 import org.apache.spark.mllib.tree.{DecisionTree, RandomForest}
@@ -25,6 +25,7 @@ import org.apache.spark.mllib.util.MLUtils._
 import org.apache.spark.rdd.RDD
 import org.nlp4l.framework.models.{Record, _}
 import org.nlp4l.framework.processors._
+import play.api.Logger
 
 import scala.util.Try
 import scalax.file.Path
@@ -35,6 +36,7 @@ class TrainAndModelProcessorFactory(settings: Config) extends ProcessorFactory(s
     new TrainAndModelProcessor(
       getStrParamRequired("workingDir"),
       getStrParam("algorithm", AlgorithmSupport.Default),
+      getConfigParam("algorithmParams", null),
       getDoubleParam("trainTestRate", 0.7)
     )
   }
@@ -42,12 +44,15 @@ class TrainAndModelProcessorFactory(settings: Config) extends ProcessorFactory(s
 
 class TrainAndModelProcessor(val workingDir: String,
                              val algorithm: String,
+                             val algorithmParams: Config,
                              val trainTestRate: Double
                             )
   extends Processor
     with CommonProcessor {
 
   val settings = new WorkingDirSettings(workingDir)
+
+  private val logger = Logger(this.getClass)
 
   override def execute(dataDict: Option[Dictionary]): Option[Dictionary] = {
 
@@ -67,17 +72,50 @@ class TrainAndModelProcessor(val workingDir: String,
 
       // Run training algorithm to build the model
       val model: ModelSupport = algorithm match {
+        case AlgorithmSupport.NaiveBayes => {
+          val lambda = getAlgorithmParamAsDouble("lamda", 1.0)
+          val modelType = getAlgorithmParam("modelType", "multinomial")
+          logger.info("algorithm: " + AlgorithmSupport.NaiveBayes + ", lambda: " + lambda + ", modelType: " + modelType)
+          new NaiveBayesModelSupport(
+            NaiveBayes.train(training, lambda, modelType)
+          )
+        }
         case AlgorithmSupport.LogisticRegressionWithLBFGS => {
           val numClasses = labelNameMap.keySet.size
+          logger.info("algorithm: " + AlgorithmSupport.LogisticRegressionWithLBFGS + ", numClasses: " + numClasses)
           new LogisticRegressionModelSupport(
             new LogisticRegressionWithLBFGS()
             .setNumClasses(numClasses)
             .run(training)
           )
         }
-        case AlgorithmSupport.NaiveBayes => {
-          new NaiveBayesModelSupport(
-            NaiveBayes.train(training, lambda = 1.0)
+        case AlgorithmSupport.DecisionTree => {
+          val numClasses = labelNameMap.keySet.size
+          val categoricalFeaturesInfo = Map[Int, Int]()
+          val impurity = getAlgorithmParam("impurity", "gini") //  "gini" (recommended)
+          val maxDepth = getAlgorithmParamAsInt("maxDepth", 5) // (suggested value: 5)
+          val maxBins = getAlgorithmParamAsInt("maxBins", 32) // (suggested value: 32)
+          logger.info("algorithm: " + AlgorithmSupport.DecisionTree + ", numClasses: " + numClasses +
+            ", impurity: " + impurity + ", maxDepth: " + maxDepth + ", maxBins: " + maxBins)
+          new DecisionTreeModelSupport(
+            DecisionTree.trainClassifier(training, numClasses, categoricalFeaturesInfo,
+              impurity, maxDepth, maxBins)
+          )
+        }
+        case AlgorithmSupport.RandomForest => {
+          val numClasses = labelNameMap.keySet.size
+          val categoricalFeaturesInfo = Map[Int, Int]()
+          val numTrees = getAlgorithmParamAsInt("numTrees", 10) // Number of trees in the random forest.
+          val featureSubsetStrategy = getAlgorithmParam("featureSubsetStrategy", "auto") // Let the algorithm choose.
+          val impurity =  getAlgorithmParam("impurity", "gini") //  "gini" (recommended)
+          val maxDepth =  getAlgorithmParamAsInt("maxDepth", 4) // ((suggested value: 4)
+          val maxBins = getAlgorithmParamAsInt("maxBins", 100) // (suggested value: 100)
+          logger.info("algorithm: " + AlgorithmSupport.RandomForest + ", numClasses: " + numClasses +
+            ", numTrees: " + numTrees + ", featureSubsetStrategy: " + featureSubsetStrategy +
+            ", impurity: " + impurity + ", maxDepth: " + maxDepth + ", maxBins: " + maxBins)
+          new RandomForestModelSupport(
+            RandomForest.trainClassifier(training, numClasses, categoricalFeaturesInfo,
+              numTrees, featureSubsetStrategy, impurity, maxDepth, maxBins)
           )
         }
         case _ => throw new IllegalArgumentException("unknown algorithm: " + algorithm)
@@ -112,4 +150,13 @@ class TrainAndModelProcessor(val workingDir: String,
     Some(dict)
   }
 
+  def getAlgorithmParam(name: String, default: String): String = {
+    if (algorithmParams != null && algorithmParams.hasPath(name)) algorithmParams.getString(name) else default
+  }
+  def getAlgorithmParamAsDouble(name: String, default: Double): Double = {
+    if (algorithmParams != null && algorithmParams.hasPath(name)) algorithmParams.getDouble(name) else default
+  }
+  def getAlgorithmParamAsInt(name: String, default: Int): Int = {
+    if (algorithmParams != null && algorithmParams.hasPath(name)) algorithmParams.getInt(name) else default
+  }
 }

--- a/examples/example-spark-mllib-classification.conf
+++ b/examples/example-spark-mllib-classification.conf
@@ -24,10 +24,12 @@
           "text"
         ],
         data: [
-          "001, title 1, AAA AAA AAA"
-          "002, title 2, AAA BBB BBB"
-          "003, title 3, CCC AAA"
-          "004, title 4, XXX XXX"
+          "001, title 1, Football is a sport game."
+          "002, title 2, Cloud Computing is Internet based ..."
+          "100, title a, AAA AAA"
+          "200, title b, AAA BBB"
+          "300, title c, CCC CCC"
+          "400, title d, DDD DDD"
         ]
       }
     }
@@ -38,15 +40,9 @@
         idField:        "docId"
         passThruFields: [ "title", "text" ]
         workingDir:   "/tmp/example-doc-class"
+        algorithm:    "NaiveBayes"
         analyzer : {
-          tokenizer {
-            factory : standard
-          }
-          filters = [
-            {
-              factory : lowercase
-            }
-          ]
+          class : org.apache.lucene.analysis.standard.StandardAnalyzer
         }
       }
     }

--- a/examples/example-spark-mllib-classification.conf
+++ b/examples/example-spark-mllib-classification.conf
@@ -27,7 +27,7 @@
           "001, title 1, Football is a sport game."
           "002, title 2, Cloud Computing is Internet based ..."
           "100, title a, AAA AAA"
-          "200, title b, AAA BBB"
+          "200, title b, BBB BBB"
           "300, title c, CCC CCC"
           "400, title d, DDD DDD"
         ]

--- a/examples/example-spark-mllib-labeled-point.conf
+++ b/examples/example-spark-mllib-labeled-point.conf
@@ -20,21 +20,31 @@
           "text"
         ],
         data: [
-          "class-A, AAA AAA AAA AAA AAA AAA"
-          "class-A, AAA AAA AAA AAA AAA AAA"
-          "class-A, AAA AAA AAA AAA AAA AAA"
-          "class-A, AAA AAA AAA AAA AAA AAA"
-          "class-A, AAA AAA AAA AAA AAA AAA"
-          "class-B, BBB BBB BBB BBB CCC"
-          "class-B, BBB BBB BBB BBB CCC"
-          "class-B, BBB BBB BBB BBB CCC"
-          "class-B, BBB BBB BBB BBB CCC"
-          "class-B, BBB BBB BBB BBB CCC"
-          "class-C, CCC CCC CCC DDD"
-          "class-C, CCC CCC CCC DDD"
-          "class-C, CCC CCC CCC DDD"
-          "class-C, CCC CCC CCC DDD"
-          "class-C, CCC CCC CCC DDD"
+          "sports, I play Baseball. Baseball is a sport game."
+          "sports, I play Soccer. Soccer is a sport game."
+          "sports, I play Basketball. Basketball is a sport game."
+          "sports, I play Volleyball. Volleyball is a sport game."
+          "sports, I play Tennis. Tennis is a sport game."
+          "computer, Internet is a technical term. Related terms are WWW, Cloud, ..."
+          "computer, Internet is a technical term. Related terms are WWW, Cloud, ..."
+          "computer, Internet is a technical term. Related terms are WWW, Cloud, ..."
+          "computer, Internet is a technical term. Related terms are WWW, Cloud, ..."
+          "computer, Internet is a technical term. Related terms are WWW, Cloud, ..."
+          "class-A, AAA AAA AAA"
+          "class-A, AAA AAA AAA"
+          "class-A, AAA AAA AAA"
+          "class-A, AAA AAA AAA"
+          "class-A, AAA AAA AAA"
+          "class-B, BBB BBB BBB"
+          "class-B, BBB BBB BBB"
+          "class-B, BBB BBB BBB"
+          "class-B, BBB BBB BBB"
+          "class-B, BBB BBB BBB"
+          "class-C, CCC CCC CCC"
+          "class-C, CCC CCC CCC"
+          "class-C, CCC CCC CCC"
+          "class-C, CCC CCC CCC"
+          "class-C, CCC CCC CCC"
         ]
       }
     }
@@ -45,14 +55,7 @@
         textField:   "text"
         workingDir:   "/tmp/example-doc-class"
         analyzer : {
-          tokenizer {
-            factory : standard
-          }
-           filters = [
-            {
-              factory : lowercase
-            }
-           ]
+          class : org.apache.lucene.analysis.standard.StandardAnalyzer
         }
       }
     }

--- a/examples/example-spark-mllib-train-model.conf
+++ b/examples/example-spark-mllib-train-model.conf
@@ -16,7 +16,7 @@
       class : org.nlp4l.framework.builtin.spark.mllib.TrainAndModelProcessorFactory
       settings : {
         workingDir:   "/tmp/example-doc-class"
-        algorithm:    "LogisticRegressionWithLBFGS"
+        algorithm:    "NaiveBayes"
         trainTestRate: 0.7
       }
     }

--- a/test/org/nlp4l/framework/builtin/spark/mllib/DocumentClassificationAlgoSpec.scala
+++ b/test/org/nlp4l/framework/builtin/spark/mllib/DocumentClassificationAlgoSpec.scala
@@ -1,0 +1,229 @@
+/*
+ * Copyright 2016 org.NLP4L
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.nlp4l.framework.builtin.spark.mllib
+
+import java.io.File
+
+import com.typesafe.config.ConfigFactory
+import org.nlp4l.framework.models.{Cell, Dictionary, Record}
+import org.specs2.mutable.{BeforeAfter, Specification}
+
+import scala.collection.mutable.ArrayBuffer
+
+class DocumentClassificationAlgoSpec extends Specification with BeforeAfter {
+
+  object TestSettings {
+    val TMP_DIR = System.getProperty("java.io.tmpdir")
+    val TEST_OUT_DIR = new File(TMP_DIR, "nlp4l-class-algo-test").getAbsolutePath.replace('\\', '/')
+  }
+  def before = {
+  }
+
+  def after = {
+  }
+  "DocumentClassificationAlgo" should {
+    "execute each algorithm" in {
+
+      val records = new ArrayBuffer[Record]
+      for(i <- 0 until 10) {
+        records += Record(Seq(
+          Cell("classification", "class-A"),
+          Cell("text", "AAA AAA AAA")))
+      }
+      for(i <- 0 until 10) {
+        records += Record(Seq(
+          Cell("classification", "class-B"),
+          Cell("text", "BBB BBB BBB")))
+      }
+      for(i <- 0 until 10) {
+        records += Record(Seq(
+          Cell("classification", "class-C"),
+          Cell("text", "CCC CCC CCC")))
+      }
+
+      // Create LabeledPoint data
+      val proc1 = new LabeledPointProcessorFactory(ConfigFactory.parseString(
+        s"""
+           |{
+           | textField:   "text"
+           | labelField:  "classification"
+           | workingDir:   "${TestSettings.TEST_OUT_DIR}"
+           | analyzer {
+           |   class : org.apache.lucene.analysis.standard.StandardAnalyzer
+           | }
+           | idfMode: "n"
+           |}
+        """.stripMargin)).getInstance()
+      val result = proc1.execute(Some(Dictionary(records)))
+      println(result)
+
+      val dict = Dictionary(Seq(
+        Record(Seq(
+          Cell("docId", "DOC-001"), Cell("title", "title 1"), Cell("text", "AAA AAA"))),
+        Record(Seq(
+          Cell("docId", "DOC-002"), Cell("title", "title 2"), Cell("text", "BBB BBB"))),
+        Record(Seq(
+          Cell("docId", "DOC-003"), Cell("title", "title 3"), Cell("text", "CCC CCC")))
+      ))
+
+      //
+      // NaiveBayes
+      //
+      println(
+        new TrainAndModelProcessorFactory(ConfigFactory.parseString(
+          s"""
+             |{
+             | workingDir:   "${TestSettings.TEST_OUT_DIR}"
+             | algorithm:    "NaiveBayes"
+             | algorithmParams {
+             |   lamda: 0.9
+             |   modelType: "multinomial"
+             | }
+             |}
+          """.stripMargin)).getInstance().execute(None)
+      )
+      val result1 = new ClassificationProcessorFactory(ConfigFactory.parseString(
+        s"""
+           |{
+           | textField:   "text"
+           | idField:     "docId"
+           | passThruFields: [
+           |   "title"
+           |   ]
+           | workingDir:   "${TestSettings.TEST_OUT_DIR}"
+           |  analyzer {
+           |   class : org.apache.lucene.analysis.standard.StandardAnalyzer
+           | }
+           | algorithm:    "NaiveBayes"
+           |}
+        """.stripMargin)).getInstance().execute(Some(dict))
+      println(result1)
+      result1.get.recordList(0).cellList(1).value mustEqual "class-A"
+      result1.get.recordList(1).cellList(1).value mustEqual "class-B"
+      result1.get.recordList(2).cellList(1).value mustEqual "class-C"
+
+      //
+      // LogisticRegressionWithLBFGS
+      //
+      println(
+        new TrainAndModelProcessorFactory(ConfigFactory.parseString(
+          s"""
+             |{
+             | workingDir:   "${TestSettings.TEST_OUT_DIR}"
+             | algorithm:    "LogisticRegressionWithLBFGS"
+             |}
+          """.stripMargin)).getInstance().execute(None)
+      )
+      val result2 = new ClassificationProcessorFactory(ConfigFactory.parseString(
+        s"""
+           |{
+           | textField:   "text"
+           | idField:     "docId"
+           | passThruFields: [
+           |   "title"
+           |   ]
+           | workingDir:   "${TestSettings.TEST_OUT_DIR}"
+           |  analyzer {
+           |   class : org.apache.lucene.analysis.standard.StandardAnalyzer
+           | }
+           | algorithm:    "LogisticRegressionWithLBFGS"
+           |}
+        """.stripMargin)).getInstance().execute(Some(dict))
+      println(result2)
+      result2.get.recordList(0).cellList(1).value mustEqual "class-A"
+      result2.get.recordList(1).cellList(1).value mustEqual "class-B"
+      result2.get.recordList(2).cellList(1).value mustEqual "class-C"
+
+      //
+      // DecisionTree
+      //
+      println(
+        new TrainAndModelProcessorFactory(ConfigFactory.parseString(
+          s"""
+             |{
+             | workingDir:   "${TestSettings.TEST_OUT_DIR}"
+             | algorithm:    "DecisionTree"
+             | algorithmParams {
+             |   impurity: "gini"
+             |   maxDepth: 6
+             |   maxBins: 33
+             | }
+             |}
+          """.stripMargin)).getInstance().execute(None)
+      )
+      val result3 = new ClassificationProcessorFactory(ConfigFactory.parseString(
+        s"""
+           |{
+           | textField:   "text"
+           | idField:     "docId"
+           | passThruFields: [
+           |   "title"
+           |   ]
+           | workingDir:   "${TestSettings.TEST_OUT_DIR}"
+           |  analyzer {
+           |   class : org.apache.lucene.analysis.standard.StandardAnalyzer
+           | }
+           | algorithm:    "DecisionTree"
+           |}
+        """.stripMargin)).getInstance().execute(Some(dict))
+      println(result3)
+      result3.get.recordList(0).cellList(1).value mustEqual "class-A"
+      result3.get.recordList(1).cellList(1).value mustEqual "class-B"
+      result3.get.recordList(2).cellList(1).value mustEqual "class-C"
+
+      //
+      // RandomForest
+      //
+      println(
+        new TrainAndModelProcessorFactory(ConfigFactory.parseString(
+          s"""
+             |{
+             | workingDir:   "${TestSettings.TEST_OUT_DIR}"
+             | algorithm:    "RandomForest"
+             | algorithmParams {
+             |   numTrees: 9
+             |   featureSubsetStrategy: "sqrt"
+             |   impurity: "gini"
+             |   maxDepth: 5
+             |   maxBins: 101
+             | }
+             |}
+          """.stripMargin)).getInstance().execute(None)
+      )
+      val result4 = new ClassificationProcessorFactory(ConfigFactory.parseString(
+        s"""
+           |{
+           | textField:   "text"
+           | idField:     "docId"
+           | passThruFields: [
+           |   "title"
+           |   ]
+           | workingDir:   "${TestSettings.TEST_OUT_DIR}"
+           |  analyzer {
+           |   class : org.apache.lucene.analysis.standard.StandardAnalyzer
+           | }
+           | algorithm:    "RandomForest"
+           |}
+        """.stripMargin)).getInstance().execute(Some(dict))
+      println(result4)
+      result4.get.recordList(0).cellList(1).value mustEqual "class-A"
+      result4.get.recordList(1).cellList(1).value mustEqual "class-B"
+      result4.get.recordList(2).cellList(1).value mustEqual "class-C"
+    }
+  }
+
+}

--- a/test/org/nlp4l/framework/builtin/spark/mllib/DocumentClassificationAlgoSpec.scala
+++ b/test/org/nlp4l/framework/builtin/spark/mllib/DocumentClassificationAlgoSpec.scala
@@ -90,7 +90,7 @@ class DocumentClassificationAlgoSpec extends Specification with BeforeAfter {
              | workingDir:   "${TestSettings.TEST_OUT_DIR}"
              | algorithm:    "NaiveBayes"
              | algorithmParams {
-             |   lamda: 0.9
+             |   lambda: 0.9
              |   modelType: "multinomial"
              | }
              |}

--- a/test/org/nlp4l/framework/builtin/spark/mllib/DocumentClassificationProcessorsSpec.scala
+++ b/test/org/nlp4l/framework/builtin/spark/mllib/DocumentClassificationProcessorsSpec.scala
@@ -18,21 +18,11 @@ package org.nlp4l.framework.builtin.spark.mllib
 
 import java.io.File
 
-import com.typesafe.config.{Config, ConfigFactory}
-import dispatch.Defaults._
-import dispatch._
-import org.nlp4l.framework.builtin.lucene.LuceneIndexingProcessorFactory
+import com.typesafe.config.ConfigFactory
 import org.nlp4l.framework.models.{Cell, Dictionary, Record}
-import org.nlp4l.lucene.{Document, Field, _}
-import org.scalatest.BeforeAndAfterAll
 import org.specs2.mutable.{BeforeAfter, Specification}
-import play.api.Logger
 
 import scala.collection.mutable.ArrayBuffer
-import scala.concurrent.Await
-import scala.concurrent.duration.Duration
-import scala.util.Try
-import scalax.file.Path
 
 class DocumentClassificationProcessorsSpec extends Specification with BeforeAfter {
 
@@ -46,7 +36,7 @@ class DocumentClassificationProcessorsSpec extends Specification with BeforeAfte
   def after = {
   }
   "DocumentClassificationProcessors" should {
-    "execute processor chain" in {
+    "execute each processor as chain" in {
 
       val config = ConfigFactory.parseString(
         s"""
@@ -95,6 +85,7 @@ class DocumentClassificationProcessorsSpec extends Specification with BeforeAfte
         s"""
            |{
            | workingDir:   "${TestSettings.TEST_OUT_DIR}"
+           | algorithm:    "LogisticRegressionWithLBFGS"
            |}
         """.stripMargin)
       val proc2 = new TrainAndModelProcessorFactory(config2).getInstance()
@@ -121,6 +112,7 @@ class DocumentClassificationProcessorsSpec extends Specification with BeforeAfte
            |     }
            |   ]
            | }
+           | algorithm:    "LogisticRegressionWithLBFGS"
            |}
         """.stripMargin)
       val proc3 = new ClassificationProcessorFactory(config3).getInstance()


### PR DESCRIPTION
Hi

DecisionTree and RandomForest are supported in the document classification processors using Spark MLLib.

Also, changed the default algorithm from LogisticRegressionWithLBFGS to NaiveBayes.
NaiveBayes seems generally match well in the document classification.
LogisticRegressionWithLBFGS also seems match well with our TF/IDF values.
I think NaiveBayes and/or LogisticRegressionWithLBFGS is/are recommended.
Unfortunatelly, I didn't get a reasonable result with DecisionTree or RandomForest.

In addition, each algorithm supports to set params in the configulation file, like the following,
<pre>
 algorithm:    "NaiveBayes"
 algorithmParams {
   lamda: 1.0
   modelType: "multinomial"
 }
</pre>
<pre>
 algorithm:    "DecisionTree"
 algorithmParams {
   impurity: "gini"
   maxDepth: 5
   maxBins: 32
 }
</pre>
<pre>
 algorithm:    "RandomForest"
 algorithmParams {
   numTrees: 10
   featureSubsetStrategy: "auto"
   impurity: "gini"
   maxDepth: 4
   maxBins: 100
 }
</pre>

Please take a look.

Thank you.
