### PR TITLE
Adding KEA processors, and so on.

### DIFF
--- a/NOTICE.txt
+++ b/NOTICE.txt
@@ -1,0 +1,15 @@
+NLP4L
+Copyright 2016 org.NLP4L
+
+This product includes the following Open Source Softwares
+
+================================================================================
+Apache License Version 2.0
+================================================================================
+
+This product includes software developed at The Apache Software Foundation (http://www.apache.org/).
+
+spark-MDLP-discretization (https://github.com/sramirez/spark-MDLP-discretization)
+[LICENSE] https://github.com/sramirez/spark-MDLP-discretization/blob/master/LICENSE
+
+================================================================================

--- a/app/org/nlp4l/framework/builtin/kea/CommonProcessor.scala
+++ b/app/org/nlp4l/framework/builtin/kea/CommonProcessor.scala
@@ -1,0 +1,160 @@
+/*
+ * Copyright 2016 org.NLP4L
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.nlp4l.framework.builtin.kea
+
+import java.io._
+import java.nio.file.FileSystems
+import java.util
+
+import com.typesafe.config.Config
+import org.apache.lucene.analysis.miscellaneous.PerFieldAnalyzerWrapper
+import org.apache.lucene.analysis.standard.StandardAnalyzer
+import org.apache.lucene.analysis.util.CharArraySet
+import org.apache.lucene.analysis.{Analyzer, TokenStream}
+import org.apache.lucene.document._
+import org.apache.lucene.index.{IndexOptions, IndexWriter, IndexWriterConfig}
+import org.apache.lucene.store.{Directory, FSDirectory}
+import org.nlp4l.framework.models.Dictionary
+import org.nlp4l.lucene.SchemaLoader
+
+import scala.util.Try
+import scalax.file.Path
+
+trait CommonProcessor {
+
+  val CONTENT_ID_FIELD_NAME = "id"
+  val FIELD_NAME = "content"
+  val DOC_SIZE_FIELD_NAME = "size"
+
+  def indexing(index: String, textField: String, data: Option[Dictionary], analyzerConfig: Config, documentSizeAnalyzerConfig: Config, withTermVectors: Boolean): Unit = {
+    val path = Path.fromString(index)
+    Try(path.deleteRecursively(continueOnFailure = false))
+
+    val indexDir: Directory = FSDirectory.open(FileSystems.getDefault.getPath(index))
+    val analyzer: Analyzer = getKEAAnalyzer(FIELD_NAME, analyzerConfig)
+    val documentSizeAnalyzer: Analyzer =
+      if (documentSizeAnalyzerConfig != null)
+        SchemaLoader.readAnalyzer(documentSizeAnalyzerConfig).delegate
+      else
+        new StandardAnalyzer(CharArraySet.EMPTY_SET)
+
+    val iwc: IndexWriterConfig = new IndexWriterConfig(analyzer)
+    val iw: IndexWriter = new IndexWriter(indexDir, iwc)
+    try {
+      data.get.recordList.zipWithIndex.foreach {
+        case (record, i) =>
+          val text = record.cellValue(textField).get.toString
+          val size = getDocumentSize(text, documentSizeAnalyzer)
+          if (withTermVectors)
+            iw.addDocument(getDocumentWithTermVectors(i.toString, text, size))
+          else
+            iw.addDocument(getDocument(i.toString, text, size))
+      }
+      iw.forceMerge(1, true)
+    }
+    finally {
+      if (iw != null)
+        iw.close()
+    }
+  }
+
+  def getFieldName(baseNamem: String, n: Int): String = {
+    baseNamem + "_" + String.valueOf(n)
+  }
+
+  def getKEAAnalyzer(fieldName: String, analyzerConfig: Config): Analyzer = {
+    val className = if (analyzerConfig != null && analyzerConfig.hasPath("class")) analyzerConfig.getString("class") else "org.nlp4l.framework.builtin.kea.KEAStandardAnalyzer"
+    val params = if (analyzerConfig != null && analyzerConfig.hasPath("params")) analyzerConfig.getConfig("params") else null
+    val constructor = Class.forName(className).getConstructor(classOf[Integer], classOf[Config])
+    val amap = new util.HashMap[String, Analyzer]
+    val a1 = constructor.newInstance(new Integer(1), params).asInstanceOf[Analyzer]
+    val a2 = constructor.newInstance(new Integer(2), params).asInstanceOf[Analyzer]
+    val a3 = constructor.newInstance(new Integer(3), params).asInstanceOf[Analyzer]
+    amap.put(getFieldName(fieldName, 1), a1)
+    amap.put(getFieldName(fieldName, 2), a2)
+    amap.put(getFieldName(fieldName, 3), a3)
+    new PerFieldAnalyzerWrapper(new StandardAnalyzer, amap)
+  }
+
+  def getDocument(contentId: String, content: String, docSize: Int): Document = {
+    val doc: Document = new Document
+    doc.add(new StringField(CONTENT_ID_FIELD_NAME, contentId, Field.Store.YES))
+    doc.add(new StoredField(DOC_SIZE_FIELD_NAME, docSize))
+    doc.add(new TextField(getFieldName(FIELD_NAME, 1), content, Field.Store.YES))
+    doc.add(new TextField(getFieldName(FIELD_NAME, 2), content, Field.Store.YES))
+    doc.add(new TextField(getFieldName(FIELD_NAME, 3), content, Field.Store.YES))
+    doc
+  }
+
+  def getDocumentWithTermVectors(contentId: String, content: String, docSize: Int): Document = {
+    val doc: Document = new Document
+    doc.add(new StringField(CONTENT_ID_FIELD_NAME, contentId, Field.Store.YES))
+    doc.add(new StoredField(DOC_SIZE_FIELD_NAME, docSize))
+    val ft: FieldType = new FieldType
+    ft.setStored(true)
+    ft.setIndexOptions(IndexOptions.DOCS_AND_FREQS_AND_POSITIONS)
+    ft.setStoreTermVectors(true)
+    doc.add(new Field(getFieldName(FIELD_NAME, 1), content, ft))
+    doc.add(new Field(getFieldName(FIELD_NAME, 2), content, ft))
+    doc.add(new Field(getFieldName(FIELD_NAME, 3), content, ft))
+    doc
+  }
+
+  def getDocumentSize(text: String, analyzer: Analyzer): Int = {
+    val stream: TokenStream = analyzer.tokenStream("dummy", text)
+    stream.reset
+    try {
+      Iterator
+        .continually(stream)
+        .takeWhile(_.incrementToken())
+        .size
+    }
+    finally {
+      stream.end
+      stream.close
+    }
+  }
+
+  def log2(num: Double): Double = {
+    Math.log(num) / Math.log(2.0)
+  }
+
+  def calcTfIdf(freq: Int, docSize: Int, docFreq: Int, docNum: Int): Double = {
+    freq.toDouble / docSize.toDouble * (-1) * log2(docFreq.toDouble / docNum.toDouble)
+  }
+
+  def calcFirstOccurrence(pos: Int, docSize: Int): Double = {
+    pos.toDouble / docSize.toDouble
+  }
+}
+
+
+class ModelDirSettings(modelDir: String) {
+
+  val LUCENE_INDEX_MODEL_DIR = new File(modelDir, "lucene-index-model").getAbsolutePath
+  val LUCENE_INDEX_EXTRACT_DIR = new File(modelDir, "lucene-index-extract").getAbsolutePath
+
+  val FEATURES_MODEL_FILE = new File(modelDir, "features-model.txt").getAbsolutePath
+  val KEYPHRASES_MODEL_FILE = new File(modelDir, "keyphrases-model.txt").getAbsolutePath
+  val CUTP_MODEL_FILE = new File(modelDir, "cutp-model.txt").getAbsolutePath
+
+}
+
+
+
+
+

--- a/app/org/nlp4l/framework/builtin/kea/KEAModelBuildProcessor.scala
+++ b/app/org/nlp4l/framework/builtin/kea/KEAModelBuildProcessor.scala
@@ -1,0 +1,260 @@
+/*
+ * Copyright 2016 org.NLP4L
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.nlp4l.framework.builtin.kea
+
+import java.io._
+import java.nio.file.FileSystems
+
+import com.typesafe.config.Config
+import org.apache.commons.io.FileUtils
+import org.apache.lucene.document.Document
+import org.apache.lucene.index.{DirectoryReader, MultiFields, PostingsEnum, TermsEnum, _}
+import org.apache.lucene.search.{DocIdSetIterator, IndexSearcher}
+import org.apache.lucene.store.{Directory, FSDirectory}
+import org.apache.spark.mllib.feature.MDLPDiscretizer
+import org.apache.spark.mllib.linalg.Vectors
+import org.apache.spark.mllib.regression.LabeledPoint
+import org.apache.spark.rdd.RDD
+import org.joda.time.DateTime
+import org.nlp4l.framework.builtin.spark.mllib.SparkContextLocal
+import org.nlp4l.framework.models.{Record, _}
+import org.nlp4l.framework.processors._
+import play.api.Logger
+import resource._
+
+import scala.collection.JavaConversions._
+
+
+class KEAModelBuildProcessorFactory(settings: Config) extends ProcessorFactory(settings) {
+
+  override def getInstance: Processor = {
+    new KEAModelBuildProcessor(
+      getStrParamRequired("textField"),
+      getStrParamRequired("keyphrasesField"),
+      getStrParam("keyphrasesSep", ","),
+      getStrParamRequired("modelDir"),
+      getConfigParam("analyzer", null),
+      getConfigParam("documentSizeAnalyzer", null),
+      getIntParam("minTF", 2)
+    )
+  }
+}
+
+class KEAModelBuildProcessor(val textField: String,
+                             val keyphrasesField: String,
+                             val keyphrasesSep: String,
+                             val modelDir: String,
+                             val analyzer: Config,
+                             val documentSizeAnalyzer: Config,
+                             val minTF: Int
+                            )
+  extends Processor
+    with CommonProcessor {
+
+  val settings = new ModelDirSettings(modelDir)
+
+  private val logger = Logger(this.getClass)
+
+  override def execute(data: Option[Dictionary]): Option[Dictionary] = {
+
+    indexing(settings.LUCENE_INDEX_MODEL_DIR, textField, data, analyzer, documentSizeAnalyzer, withTermVectors = false)
+
+    val keyphrasesMap: Map[String, Set[String]] =
+      data.get.recordList.zipWithIndex.map {
+        case (record, i) => {
+          val keyphrases = record.cellValue(keyphrasesField).get.toString
+          val keyphraseSet = keyphrases.split(keyphrasesSep).map(_.trim())
+          (i.toString, keyphraseSet.toSet)
+        }
+      }.map(a => a._1 -> a._2).toMap
+
+    val model = buildModel(keyphrasesMap)
+    model.save(settings.FEATURES_MODEL_FILE, settings.KEYPHRASES_MODEL_FILE)
+
+    transformToMDLPDiscretizationModel(settings.FEATURES_MODEL_FILE, settings.CUTP_MODEL_FILE)
+
+    val result = "success"
+    val dict = Dictionary(Seq(
+      Record(Seq(
+        Cell("result", result)
+      ))))
+    Some(dict)
+  }
+
+  def buildModel(knownKeyphrases: Map[String, Set[String]]): KEAModel = {
+    val indexDir: Directory = FSDirectory.open(FileSystems.getDefault.getPath(settings.LUCENE_INDEX_MODEL_DIR))
+    val ir: IndexReader = DirectoryReader.open(indexDir)
+    val model: KEAModel = new KEAModel(ir, knownKeyphrases)
+    try {
+      (1 to 3).foreach(n => {
+        logger.info(new DateTime().toString + " : building " + n + "-gram model")
+        val fieldName: String = getFieldName(FIELD_NAME, n)
+        val terms: Terms = MultiFields.getTerms(ir, fieldName)
+        val te: TermsEnum = terms.iterator
+        Iterator.continually(te.next()).takeWhile(_ != null).foreach(rawPhrase => {
+          val phrase: String = rawPhrase.utf8ToString
+          // use KEAStopFilter instead
+          //if(stopWords(phrase, n)) continue;
+
+          val de: PostingsEnum = MultiFields.getTermDocsEnum(ir, fieldName, rawPhrase)
+          while (de.nextDoc != DocIdSetIterator.NO_MORE_DOCS) {
+            val docId: Int = de.docID
+            val freq: Int = de.freq
+            // Let's consider only terms that occurs more than one time in the document
+            // KEA papers said "To reduce the size of the training set, we discard any phrase that occurs only once in the document."
+
+            if (freq >= minTF) {
+              val pe: PostingsEnum = MultiFields.getTermPositionsEnum(ir, fieldName, rawPhrase)
+              val ret: Int = pe.advance(docId)
+              if (ret == DocIdSetIterator.NO_MORE_DOCS) {
+                throw new RuntimeException("no more docs...")
+              } else {
+                // get first position of the term in the doc (first occurrence)
+                val pos: Int = pe.nextPosition
+                model.add(docId, fieldName, phrase, freq, pos)
+              }
+            }
+          }
+        })
+      })
+    } finally {
+      if (ir != null)
+        ir.close()
+    }
+    model
+  }
+
+  class KEAModel(val reader: IndexReader, val knownKeyphrases: Map[String, Set[String]]) {
+    val searcher: IndexSearcher = new IndexSearcher(reader)
+    val dmMap = scala.collection.mutable.Map.empty[String, KEADocModel]
+    val docFreqMap = scala.collection.mutable.Map.empty[String, Integer]
+    val docSizeMap = scala.collection.mutable.Map.empty[String, Integer]
+    val docNum = reader.numDocs
+
+    def add(docId: Int, fieldName: String, phrase: String, freq: Int, pos: Int) {
+      val doc: Document = searcher.doc(docId)
+      val contentId: String = doc.get(CONTENT_ID_FIELD_NAME)
+      val docModel: KEADocModel = getDocModel(contentId)
+      docModel.setPhraseFeatures(phrase, freq, pos, docSize(docId, contentId), docFreq(fieldName, phrase), docNum)
+    }
+
+    def getDocModel(contentId: String): KEADocModel = {
+      dmMap.get(contentId) match {
+        case Some(v) => v
+        case None => {
+          val dm = new KEADocModel
+          dmMap.put(contentId, dm)
+          dm
+        }
+      }
+    }
+
+    def docSize(docId: Int, contentId: String): Int = {
+      docSizeMap.get(contentId) match {
+        case Some(v) => v
+        case None => {
+          val size = searcher.doc(docId).get(DOC_SIZE_FIELD_NAME).toInt
+          docSizeMap.put(contentId, size)
+          size
+        }
+      }
+    }
+
+    def docFreq(fieldName: String, phrase: String): Int = {
+      docFreqMap.get(phrase) match {
+        case Some(v) => v
+        case None => {
+          val dfreq = reader.docFreq(new Term(fieldName, phrase))
+          docFreqMap.put(phrase, dfreq)
+          dfreq
+        }
+      }
+    }
+
+    def save(featuresFilename: String, keyphrasesFilename: String) {
+      for (featuresOut <- managed(new PrintWriter(featuresFilename));
+           keyphrasesOut <- managed(new PrintWriter(keyphrasesFilename))) {
+        for (id <- dmMap.keySet.toSeq.sorted) {
+          keyphrasesOut.println("")
+          keyphrasesOut.println("* content id = %s".format(id))
+          keyphrasesOut.println(" - doc size = %d".format(docSizeMap.get(id).get.toInt))
+          keyphrasesOut.println(" - known keyphrases")
+          val knowKeyphraseSet: Set[String] = knownKeyphrases(id)
+          for (keyphrase <- knowKeyphraseSet) {
+            keyphrasesOut.println(keyphrase)
+          }
+          keyphrasesOut.println(" - features")
+          val docModel: KEADocModel = dmMap.get(id).get
+          for (keyphrase <- docModel.ps.keySet) {
+            val ps: PhraseStats = docModel.ps.get(keyphrase).get
+            val class1: Boolean = knowKeyphraseSet.contains(keyphrase)
+            keyphrasesOut.println("%s = %d %g %g".format(keyphrase, if (class1) 1 else 0, ps.tfidf, ps.firstOccurrence))
+            featuresOut.println("%g %g %s".format(ps.tfidf, ps.firstOccurrence, class1))
+          }
+        }
+      }
+    }
+  }
+
+  class KEADocModel {
+    val ps = scala.collection.mutable.Map.empty[String, PhraseStats]
+
+    def setPhraseFeatures(phrase: String, freq: Int, pos: Int, docSize: Int, docFreq: Int, docNum: Int) {
+      ps.put(phrase, new PhraseStats(freq, pos, docSize, docFreq, docNum))
+    }
+  }
+
+  class PhraseStats(val freq: Int, val pos: Int, val docSize: Int, val docFreq: Int, val docNum: Int) {
+    val tfidf = calcTfIdf(freq, docSize, docFreq, docNum)
+    val firstOccurrence = calcFirstOccurrence(pos, docSize)
+  }
+
+  def transformToMDLPDiscretizationModel(featuresModelFile: String, cutpModelFile: String): Unit = {
+    val lines: Seq[String] = FileUtils.readLines(new File(featuresModelFile))
+    val featuresData: Seq[(Int, Map[Int, Double])] = lines.map {
+      line => {
+        val values: Array[String] = line.split("\\s")
+        val bool = if (values(2).toBoolean) 1 else 0
+        val v1 = values(0).toDouble
+        val v2 = values(1).toDouble
+        (bool, Map(0 -> v1, 1 -> v2))
+      }
+    }
+    val sc = SparkContextLocal.newSparkContext("KEAModelBuildProcessor")
+    val discretizer = try {
+      val data: RDD[LabeledPoint] = sc
+        .parallelize(featuresData)
+        .map { case ((labelInt, values)) =>
+          val features = Vectors.sparse(2, values.toSeq)
+          val label = labelInt.toDouble
+          LabeledPoint(label, features)
+        }
+      MDLPDiscretizer.train(data)
+    }
+    finally {
+      if (sc != null)
+        sc.stop()
+    }
+    for (cutpModelOut <- managed(new PrintWriter(cutpModelFile))) {
+      cutpModelOut.println(discretizer.thresholds(0).map("%g".format(_)).mkString(" "))
+      cutpModelOut.println(discretizer.thresholds(1).map("%g".format(_)).mkString(" "))
+    }
+
+  }
+
+}
+

--- a/app/org/nlp4l/framework/builtin/kea/KEAStandardAnalyzer.java
+++ b/app/org/nlp4l/framework/builtin/kea/KEAStandardAnalyzer.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright 2016 org.NLP4L
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.nlp4l.framework.builtin.kea;
+
+import com.typesafe.config.Config;
+import org.apache.commons.io.FileUtils;
+import org.apache.lucene.analysis.Analyzer;
+import org.apache.lucene.analysis.TokenStream;
+import org.apache.lucene.analysis.Tokenizer;
+import org.apache.lucene.analysis.core.LowerCaseFilter;
+import org.apache.lucene.analysis.shingle.ShingleFilter;
+import org.apache.lucene.analysis.standard.StandardTokenizer;
+import org.apache.lucene.analysis.util.CharArraySet;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.List;
+
+
+public class KEAStandardAnalyzer extends Analyzer {
+
+  private final int n;
+  private final Config params;
+
+  private CharArraySet stopWords = KEAStopWords.defaultStopWords;
+  private CharArraySet beginStopWords = KEAStopWords.defaultBeginStopWords;
+  private CharArraySet endStopWords = KEAStopWords.defaultEndStopWords;
+
+  public KEAStandardAnalyzer(Integer n, Config params) {
+    this.n = n;
+    this.params = params;
+    if (params != null) {
+      if (params.hasPath("stopwords") || params.hasPath("stopwordsFile")) {
+        String[] words;
+        if (params.hasPath("stopwords")) {
+          words = params.getString("stopwords").split(",");
+        } else{
+          String stopwordsFile = params.getString("stopwordsFile");
+          try {
+            List<String> lines = FileUtils.readLines(new File(stopwordsFile));
+            words = lines.toArray(new String[lines.size()]);
+          } catch (IOException e) {
+            throw new RuntimeException(e);
+          }
+        }
+        for (int i = 0; i < words.length; i++) {
+          words[i] = words[i].trim();
+        }
+        CharArraySet[] set = KEAStopWords.createStopWordsSet(words);
+        stopWords = set[0];
+        beginStopWords = set[1];
+        endStopWords = set[2];
+      }
+    }
+  }
+
+  @Override
+  protected TokenStreamComponents createComponents(String fieldName) {
+    Tokenizer source = new StandardTokenizer();
+    TokenStream lcf = new LowerCaseFilter(source);
+    if (n == 1) {
+      TokenStream stf = new KEAStopFilter(lcf, n, stopWords, beginStopWords, endStopWords);
+      return new TokenStreamComponents(source, stf);
+    } else {
+      assert n >= 2;
+      ShingleFilter shf = new ShingleFilter(lcf, n, n);
+      shf.setOutputUnigrams(false);
+      KEAStopFilter keasf = new KEAStopFilter(shf, n, stopWords, beginStopWords, endStopWords);
+      return new TokenStreamComponents(source, keasf);
+    }
+  }
+}

--- a/app/org/nlp4l/framework/builtin/kea/KEAStopFilter.java
+++ b/app/org/nlp4l/framework/builtin/kea/KEAStopFilter.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2016 org.NLP4L
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.nlp4l.framework.builtin.kea;
+
+import org.apache.lucene.analysis.TokenStream;
+import org.apache.lucene.analysis.tokenattributes.CharTermAttribute;
+import org.apache.lucene.analysis.util.CharArraySet;
+import org.apache.lucene.analysis.util.FilteringTokenFilter;
+
+import java.io.IOException;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+public class KEAStopFilter extends FilteringTokenFilter {
+
+  private final int n;
+  private final CharArraySet stopWords, beginStopWords, endStopWords;
+  private final CharTermAttribute termAtt = addAttribute(CharTermAttribute.class);
+
+  public static Pattern patNumbers = Pattern.compile("^\\d+$");
+
+  public KEAStopFilter(TokenStream in, int n, CharArraySet stopWords, CharArraySet beginStopWords, CharArraySet endStopWords) {
+    super(in);
+    this.n = n;
+    this.stopWords = stopWords;
+    this.beginStopWords = beginStopWords;
+    this.endStopWords = endStopWords;
+  }
+
+  @Override
+  protected boolean accept() throws IOException {
+    String phrase = termAtt.toString();
+    if (n == 1) {
+      if (stopWords.contains(phrase)) return false;
+
+      if (phrase.length() == 1) return false;
+
+      Matcher m = patNumbers.matcher(phrase);
+      return !m.find();
+    } else {
+      assert n >= 2;
+      String words[] = phrase.split(" ");
+      if (beginStopWords.contains(words[0] + " ")) return false;
+      else if (endStopWords.contains(" " + words[words.length - 1])) return false;
+      return true;
+    }
+  }
+}

--- a/app/org/nlp4l/framework/builtin/kea/KEAStopWords.java
+++ b/app/org/nlp4l/framework/builtin/kea/KEAStopWords.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2016 org.NLP4L
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.nlp4l.framework.builtin.kea;
+
+import org.apache.lucene.analysis.util.CharArraySet;
+
+
+public class KEAStopWords {
+
+  // feel free to add your stop words to this list if needed
+  static final String STOP_WORDS = "a,an,and,are,as,at,be,but,by,for,if,in,into,is,it,no,not,of,on,or,such,that,the,their,then,there,these,they,this,to,was,will,with" // using Lucene's stop words
+    + ",after,although,because,before,even,how,lest,once,since,than,though,till,unless,until,when,what,whatever,whenever,where,whereas,wherever,whether,which,whichever,while,who,whose,why" // conjunctions
+    + ",about,above,across,ago,below,beside,besides,from,off,onto,over,past,through,toward,towards,under" // prepositions
+    + ",he,her,hers,herself,him,himself,his,i,its,itself,me,mine,my,myself,our,ours,ourselves,she,theirs,them,themselves,us,we,you,your,yours,yourself,yourselves" // pronouns
+    + ",been,became,become,began,begin,begun,came,come,coming,did,didn't,do,don't,does,doesn't,doing,done,gave,get,getting,give,given,go,gone,got,gotten,had,have,keep,kept,knew,know,known,leave,left,let,went,were" // anomalous verbs
+    + ",can,cannot,can't,could,couldn't,made,make,ought,said,say,send,sent,shall,should,shouldn't,take,taken,tell,think,thought,told,took,will,would,wouldn't";
+
+  public static final CharArraySet defaultStopWords = new CharArraySet(STOP_WORDS.length(), true);
+  public static final CharArraySet defaultBeginStopWords = new CharArraySet(STOP_WORDS.length(), true);
+  public static final CharArraySet defaultEndStopWords = new CharArraySet(STOP_WORDS.length(), true);
+
+  static {
+    String[] words = STOP_WORDS.split(",");
+    for (String word : words) {
+      defaultStopWords.add(word);
+      defaultBeginStopWords.add(word + " ");
+      defaultEndStopWords.add(" " + word);
+    }
+  }
+  public static CharArraySet[] createStopWordsSet(String[] words) {
+    CharArraySet[] set = new CharArraySet[3];
+    set[0] = new CharArraySet(words.length, true);
+    set[1] = new CharArraySet(words.length, true);
+    set[2] = new CharArraySet(words.length, true);
+    for (String word : words) {
+      set[0].add(word);
+      set[1].add(word + " ");
+      set[2].add(" " + word);
+    }
+    return set;
+  }
+
+}
+

--- a/app/org/nlp4l/framework/builtin/kea/KeyphraseExtractionProcessor.scala
+++ b/app/org/nlp4l/framework/builtin/kea/KeyphraseExtractionProcessor.scala
@@ -1,0 +1,322 @@
+/*
+ * Copyright 2016 org.NLP4L
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.nlp4l.framework.builtin.kea
+
+import java.io._
+import java.nio.file.FileSystems
+
+import com.typesafe.config.Config
+import org.apache.commons.io.FileUtils
+import org.apache.lucene.document.Document
+import org.apache.lucene.index.{DirectoryReader, Terms, TermsEnum, _}
+import org.apache.lucene.search.{DocIdSetIterator, IndexSearcher, TermQuery, TopDocs}
+import org.apache.lucene.store.{Directory, FSDirectory}
+import org.apache.lucene.util.BytesRef
+import org.nlp4l.framework.models._
+import org.nlp4l.framework.processors._
+import play.api.Logger
+
+import scala.collection.JavaConversions._
+import scala.collection.mutable.ArrayBuffer
+
+class KeyphraseExtractionProcessorFactory(settings: Config) extends ProcessorFactory(settings) {
+
+  override def getInstance: Processor = {
+    new KeyphraseExtractionProcessor(
+      getStrParamRequired("idField"),
+      getStrParamRequired("textField"),
+      getStrParamRequired("modelDir"),
+      getStrParam("keyphrasesSep", ","),
+      getBoolParam("incrementDfDocNum", true),
+      getStrParam("nGramPriorityOrder", "3,2,1"),
+      getIntParam("maxKeyphrases", 20),
+      getDoubleParam("scoreThreshold", 0.0),
+      getStrListParam("passThruFields", null),
+      getConfigParam("analyzer", null),
+      getConfigParam("documentSizeAnalyzer", null),
+      getIntParam("minTF", 2)
+    )
+  }
+}
+
+class KeyphraseExtractionProcessor(val idField: String,
+                                   val textField: String,
+                                   val modelDir: String,
+                                   val keyphrasesSep: String,
+                                   val incrementDfDocNum: Boolean,
+                                   val nGramPriorityOrder: String,
+                                   val maxKeyphrases: Int,
+                                   val scoreThreshold: Double,
+                                   val passThruFields: Seq[String],
+                                   val analyzer: Config,
+                                   val documentSizeAnalyzer: Config,
+                                   val minTF: Int
+                                  )
+  extends Processor
+    with CommonProcessor {
+
+  val settings = new ModelDirSettings(modelDir)
+
+  private val logger = Logger(this.getClass)
+
+  override def execute(data: Option[Dictionary]): Option[Dictionary] = {
+    val discr: Discretization = new Discretization(settings.CUTP_MODEL_FILE)
+    val model: Model = new Model(settings.FEATURES_MODEL_FILE, discr)
+    logger.debug(model.toString)
+
+    indexing(settings.LUCENE_INDEX_EXTRACT_DIR, textField, data, analyzer, documentSizeAnalyzer, withTermVectors = true)
+
+    val indexDir: Directory = FSDirectory.open(FileSystems.getDefault.getPath(settings.LUCENE_INDEX_EXTRACT_DIR))
+    val ir: IndexReader = DirectoryReader.open(indexDir)
+    val searcher: IndexSearcher = new IndexSearcher(ir)
+    try {
+      val resultRecords: ArrayBuffer[Record] = new ArrayBuffer[Record]()
+      val indexModelDir: Directory = FSDirectory.open(FileSystems.getDefault.getPath(settings.LUCENE_INDEX_MODEL_DIR))
+      val irModel: IndexReader = DirectoryReader.open(indexModelDir)
+      try {
+        data.get.recordList.zipWithIndex.foreach {
+          case (record, i) =>
+            val result: Seq[KeyphraseScore] = extractKeyphrases(i.toString, model, discr, incrementDfDocNum, nGramPriorityOrder, ir, searcher, irModel)
+            for (kps <- result) {
+              logger.debug(kps.toString)
+            }
+            val cells = new ArrayBuffer[Cell]
+            // doc id
+            cells += record.cellMap(idField)
+            // classification
+            cells += Cell("keyphrases", result.map(_.keyphrase).mkString(keyphrasesSep))
+            // pass thru
+            if (passThruFields != null) {
+              passThruFields.foreach { passThruField =>
+                cells += record.cellMap(passThruField)
+              }
+            }
+            resultRecords += Record(cells.toSeq)
+        }
+
+      } finally {
+        if (irModel != null)
+          irModel.close()
+      }
+      Some(Dictionary(resultRecords.toSeq))
+    } finally {
+      if (ir != null)
+        ir.close()
+    }
+  }
+
+  def extractKeyphrases(contetId: String, model: Model, discr: Discretization, incrementDfDocNum: Boolean, nGramPriorityOrder: String, ir: IndexReader, searcher: IndexSearcher, irModel: IndexReader): Seq[KeyphraseScore] = {
+    val kpsArray: ArrayBuffer[KeyphraseScore] = new ArrayBuffer[KeyphraseScore]()
+    nGramPriorityOrder.split(",").map(_.toInt).foreach(n => {
+      val fieldName: String = getFieldName(FIELD_NAME, n)
+      val docId: Int = getDocId(searcher, contetId)
+      val docSize: Int = getDocSize(searcher, docId)
+      // get numDocs from the model index
+      val numDocs: Int = irModel.numDocs
+      val terms: Terms = ir.getTermVector(docId, fieldName)
+      val te: TermsEnum = terms.iterator
+      Iterator.continually(te.next()).takeWhile(_ != null).foreach(rawPhrase => {
+        val phrase: String = rawPhrase.utf8ToString
+        val features: Array[Double] = getFeatures(ir, fieldName, rawPhrase, docId, docSize, numDocs, irModel, incrementDfDocNum)
+        if (features != null) {
+          val kps = new KeyphraseScore(phrase, features, model, discr, n)
+          if (kps.score >= scoreThreshold)
+            kpsArray.add(kps)
+        }
+      })
+    })
+
+    val kpsResult: ArrayBuffer[KeyphraseScore] = new ArrayBuffer[KeyphraseScore]()
+    val kpsScoredOrder = kpsArray.sortWith((o1, o2) =>
+      if (o1.score == o2.score)
+        if (o1.tfidf == o2.tfidf)
+          nGramPriorityOrder.indexOf(o1.nGram) < nGramPriorityOrder.indexOf(o2.nGram)
+        else
+          o1.tfidf > o2.tfidf
+      else
+        o1.score > o2.score
+    )
+    kpsScoredOrder.foreach { kps =>
+      if (!subphraseOf(kps, kpsResult))
+        kpsResult.add(kps)
+    }
+    kpsResult.take(maxKeyphrases)
+  }
+
+  def subphraseOf(kps: KeyphraseScore, list: Seq[KeyphraseScore]): Boolean = {
+    list.exists(_.keyphrase.indexOf(kps.keyphrase) >= 0)
+  }
+
+  def getDocId(searcher: IndexSearcher, contentId: String): Int = {
+    val topDocs: TopDocs = searcher.search(new TermQuery(new Term(CONTENT_ID_FIELD_NAME, contentId)), 1)
+    if (topDocs.totalHits == 0) throw new RuntimeException(contentId + " cannot be found in the index.")
+    topDocs.scoreDocs(0).doc
+  }
+
+  def getDocSize(searcher: IndexSearcher, docId: Int): Int = {
+    val doc: Document = searcher.doc(docId)
+    doc.get(DOC_SIZE_FIELD_NAME).toInt
+  }
+
+  def getFeatures(ir: IndexReader, fieldName: String, rawPhrase: BytesRef, docId: Int, docSize: Int, numDocs: Int, irModel: IndexReader, inc: Boolean): Array[Double] = {
+    val de: PostingsEnum = MultiFields.getTermDocsEnum(ir, fieldName, rawPhrase)
+    val ret: Int = de.advance(docId)
+    if (ret == DocIdSetIterator.NO_MORE_DOCS) {
+      throw new RuntimeException("no more docs...")
+    }
+    else {
+      val freq: Int = de.freq
+      if (freq >= minTF) {
+        val pe: PostingsEnum = MultiFields.getTermPositionsEnum(ir, fieldName, rawPhrase)
+        val ret2: Int = pe.advance(docId)
+        if (ret2 == DocIdSetIterator.NO_MORE_DOCS) {
+          throw new RuntimeException("no more docs...")
+        }
+        else {
+          val features: Array[Double] = new Array[Double](2)
+          val pos: Int = pe.nextPosition
+          // get docFreq from the model index
+          val docFreq: Int = irModel.docFreq(new Term(fieldName, rawPhrase))
+          features(0) = calcTfIdf(freq, docSize,
+            if (inc) docFreq + 1 else docFreq,
+            if (inc) numDocs + 1 else numDocs)
+          features(1) = calcFirstOccurrence(pos, docSize)
+          features
+        }
+      } else null
+    }
+  }
+
+  class Discretization(val file: String) {
+
+    val (featuresTfIdf: Seq[Double], featuresDistance: Seq[Double]) = readFile(file)
+
+    def readFile(file: String): (Seq[Double], Seq[Double]) = {
+      val br = new BufferedReader(new FileReader(new File(file)))
+      try {
+        val line1: String = br.readLine
+        val line2: String = br.readLine
+        val seq1 = line1.trim.split("\\s").map(_.toDouble).toSeq
+        val seq2 = line2.trim.split("\\s").map(_.toDouble).toSeq
+        (seq1, seq2)
+      }
+      finally {
+        if (br != null)
+          br.close()
+      }
+    }
+
+    def discretizeTfIdf(value: Double): Int = {
+      val result = featuresTfIdf.zipWithIndex.find {
+        case (tfidf, i) => value < tfidf
+      }
+      if (result.isEmpty) featuresTfIdf.length else result.get._2
+    }
+
+    def discretizeDistance(value: Double): Int = {
+      val result = featuresDistance.zipWithIndex.find {
+        case (distance, i) => value < distance
+      }
+      if (result.isEmpty) featuresDistance.length else result.get._2
+    }
+  }
+
+  class Model(val file: String, val discr: Discretization) {
+    val numTfIdf: Int = discr.featuresTfIdf.length + 1
+    val numDistance: Int = discr.featuresDistance.length + 1
+
+    val countTfIdfYes: Array[Int] = new Array[Int](numTfIdf)
+    val countTfIdfNo: Array[Int] = new Array[Int](numTfIdf)
+    val countDistanceYes: Array[Int] = new Array[Int](numDistance)
+    val countDistanceNo: Array[Int] = new Array[Int](numDistance)
+    val countYesNo: Array[Int] = new Array[Int](2)
+
+    val lines: Seq[String] = FileUtils.readLines(new File(file))
+    lines.foreach { line => {
+      val values: Array[String] = line.split("\\s")
+      if (values(2).toBoolean) {
+        countTfIdfYes(discr.discretizeTfIdf(values(0).toDouble)) += 1
+        countDistanceYes(discr.discretizeDistance(values(1).toDouble)) += 1
+        countYesNo(0) += 1
+      }
+      else {
+        countTfIdfNo(discr.discretizeTfIdf(values(0).toDouble)) += 1
+        countDistanceNo(discr.discretizeDistance(values(1).toDouble)) += 1
+        countYesNo(1) += 1
+      }
+    }
+    }
+    val countYes: Int = countYesNo(0)
+    val countNo: Int = countYesNo(1)
+
+    val priorProbYes = countYes.toDouble / (countYes + countNo).toDouble
+    val priorProbNo = countNo.toDouble / (countYes + countNo).toDouble
+
+    val probTfIdfYes = new Array[Double](numTfIdf)
+    val probTfIdfNo = new Array[Double](numTfIdf)
+    val probDistanceYes = new Array[Double](numDistance)
+    val probDistanceNo = new Array[Double](numDistance)
+
+    (0 until numTfIdf).foreach(n => {
+      probTfIdfYes(n) = countTfIdfYes(n).toDouble / countYes.toDouble
+      probTfIdfNo(n) = countTfIdfNo(n).toDouble / countNo.toDouble
+    })
+    (0 until numDistance).foreach(n => {
+      probDistanceYes(n) = countDistanceYes(n).toDouble / countYes.toDouble
+      probDistanceNo(n) = countDistanceNo(n).toDouble / countNo.toDouble
+    })
+
+    override def toString: String = {
+      val b = new StringBuilder
+      b.append("model =")
+      b.append("\ntfidf | yes    = ")
+      for (p <- probTfIdfYes) {
+        b.append(" %8.6f".format(p))
+      }
+      b.append("\ntfidf | no     = ")
+      for (p <- probTfIdfNo) {
+        b.append(" %8.6f".format(p))
+      }
+      b.append("\ndistance | yes = ")
+      for (p <- probDistanceYes) {
+        b.append(" %8.6f".format(p))
+      }
+      b.append("\ndistance | no  = ")
+      for (p <- probDistanceNo) {
+        b.append(" %8.6f".format(p))
+      }
+      b.append("\nP(yes) = %8.6f".format(priorProbYes))
+      b.append("\nP(no)  = %8.6f".format(priorProbNo))
+      b.append("\n")
+      b.result()
+    }
+  }
+
+  class KeyphraseScore(val keyphrase: String, val features: Array[Double], val model: Model, val discr: Discretization, val nGram: Int) {
+    val tfidf: Double = features(0)
+    val discrTfIdf: Int = discr.discretizeTfIdf(features(0))
+    val discrDistance: Int = discr.discretizeDistance(features(1))
+    val probYes: Double = model.priorProbYes * model.probTfIdfYes(discrTfIdf) * model.probDistanceYes(discrDistance)
+    val probNo: Double = model.priorProbNo * model.probTfIdfNo(discrTfIdf) * model.probDistanceNo(discrDistance)
+    val score: Double = probYes / (probYes + probNo)
+
+    override def toString: String = {
+      "%s (%8.6f,%8.6f)".format(keyphrase, score, tfidf)
+    }
+  }
+
+}

--- a/app/org/nlp4l/framework/builtin/spark/mllib/ClassificationProcessor.scala
+++ b/app/org/nlp4l/framework/builtin/spark/mllib/ClassificationProcessor.scala
@@ -29,7 +29,7 @@ class ClassificationProcessorFactory(settings: Config) extends ProcessorFactory(
 
   override def getInstance: Processor = {
     new ClassificationProcessor(
-      getStrParamRequired("workingDir"),
+      getStrParamRequired("modelDir"),
       getStrParamRequired("textField"),
       getStrParamRequired("idField"),
       getStrListParam("passThruFields", null),
@@ -39,7 +39,7 @@ class ClassificationProcessorFactory(settings: Config) extends ProcessorFactory(
   }
 }
 
-class ClassificationProcessor(val workingDir: String,
+class ClassificationProcessor(val modelDir: String,
                               val textField: String,
                               val idField: String,
                               val passThruFields: Seq[String],
@@ -49,7 +49,7 @@ class ClassificationProcessor(val workingDir: String,
   extends Processor
     with CommonProcessor {
 
-  val settings = new WorkingDirSettings(workingDir)
+  val settings = new ModelDirSettings(modelDir)
 
   override def execute(dictData: Option[Dictionary]): Option[Dictionary] = {
 

--- a/app/org/nlp4l/framework/builtin/spark/mllib/CommonProcessor.scala
+++ b/app/org/nlp4l/framework/builtin/spark/mllib/CommonProcessor.scala
@@ -211,15 +211,15 @@ object SparkContextLocal {
 
 }
 
-class WorkingDirSettings(workingDir: String) {
+class ModelDirSettings(modelDir: String) {
 
-  val LUCENE_INDEX_DIR = new File(workingDir, "lucene").getAbsolutePath
-  val LABEL_FILE = new File(workingDir, "label.txt").getAbsolutePath
-  val DATA_FILE  = new File(workingDir, "data.txt").getAbsolutePath
-  val WORDS_FILE = new File(workingDir, "words.txt").getAbsolutePath
-  val TFIDF_FILE = new File(workingDir, "tfidf-params.txt").getAbsolutePath
-  val VALUES_FILE_DIR = new File(workingDir, "values").getAbsolutePath
-  val MODEL_FILE_DIR = new File(workingDir, "model").getAbsolutePath
+  val LUCENE_INDEX_DIR = new File(modelDir, "lucene").getAbsolutePath
+  val LABEL_FILE = new File(modelDir, "label.txt").getAbsolutePath
+  val DATA_FILE  = new File(modelDir, "data.txt").getAbsolutePath
+  val WORDS_FILE = new File(modelDir, "words.txt").getAbsolutePath
+  val TFIDF_FILE = new File(modelDir, "tfidf-params.txt").getAbsolutePath
+  val VALUES_FILE_DIR = new File(modelDir, "values").getAbsolutePath
+  val MODEL_FILE_DIR = new File(modelDir, "model").getAbsolutePath
 
   val LABEL_FILE_SEP  = "\t"
   val DATA_FILE_SEP  = " "

--- a/app/org/nlp4l/framework/builtin/spark/mllib/LabeledPointProcessor.scala
+++ b/app/org/nlp4l/framework/builtin/spark/mllib/LabeledPointProcessor.scala
@@ -31,7 +31,7 @@ class LabeledPointProcessorFactory(settings: Config) extends ProcessorFactory(se
 
   override def getInstance: Processor = {
     new LabeledPointProcessor(
-      getStrParamRequired("workingDir"),
+      getStrParamRequired("modelDir"),
       getStrParamRequired("labelField"),
       getStrParamRequired("textField"),
       getStrListParam("valuesFields", null),
@@ -59,7 +59,7 @@ class LabeledPointProcessorFactory(settings: Config) extends ProcessorFactory(se
   }
 }
 
-class LabeledPointProcessor(val workingDir: String,
+class LabeledPointProcessor(val modelDir: String,
                             val labelField: String,
                             val textField: String,
                             val valuesFields: Seq[String],
@@ -100,7 +100,7 @@ class LabeledPointProcessor(val workingDir: String,
        | }
         """.stripMargin)
 
-  val settings = new WorkingDirSettings(workingDir)
+  val settings = new ModelDirSettings(modelDir)
 
   override def execute(data: Option[Dictionary]): Option[Dictionary] = {
 

--- a/app/org/nlp4l/framework/builtin/spark/mllib/TrainAndModelProcessor.scala
+++ b/app/org/nlp4l/framework/builtin/spark/mllib/TrainAndModelProcessor.scala
@@ -34,7 +34,7 @@ class TrainAndModelProcessorFactory(settings: Config) extends ProcessorFactory(s
 
   override def getInstance: Processor = {
     new TrainAndModelProcessor(
-      getStrParamRequired("workingDir"),
+      getStrParamRequired("modelDir"),
       getStrParam("algorithm", AlgorithmSupport.Default),
       getConfigParam("algorithmParams", null),
       getDoubleParam("trainTestRate", 0.7)
@@ -42,7 +42,7 @@ class TrainAndModelProcessorFactory(settings: Config) extends ProcessorFactory(s
   }
 }
 
-class TrainAndModelProcessor(val workingDir: String,
+class TrainAndModelProcessor(val modelDir: String,
                              val algorithm: String,
                              val algorithmParams: Config,
                              val trainTestRate: Double
@@ -50,7 +50,7 @@ class TrainAndModelProcessor(val workingDir: String,
   extends Processor
     with CommonProcessor {
 
-  val settings = new WorkingDirSettings(workingDir)
+  val settings = new ModelDirSettings(modelDir)
 
   private val logger = Logger(this.getClass)
 

--- a/app/org/nlp4l/lucene/stats/RawWordCounts.java
+++ b/app/org/nlp4l/lucene/stats/RawWordCounts.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 RONDHUIT Co.,LTD.
+ * Copyright 2016 org.NLP4L
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/org/nlp4l/sample/SampleCsvImportProcessor.scala
+++ b/app/org/nlp4l/sample/SampleCsvImportProcessor.scala
@@ -20,7 +20,7 @@ import java.io._
 import java.nio.charset.Charset
 
 import com.typesafe.config.Config
-import org.apache.commons.csv.{CSVFormat, CSVParser}
+import org.apache.commons.csv.{CSVFormat, CSVParser, QuoteMode}
 import org.nlp4l.framework.models.{Record, _}
 import org.nlp4l.framework.processors._
 
@@ -41,7 +41,7 @@ class SampleCsvImportProcessorFactory(settings: Config) extends ProcessorFactory
 class SampleCsvImportProcessor(val file: String, val encoding: String, val fields: Seq[String]) extends Processor {
 
   override def execute(data: Option[Dictionary]): Option[Dictionary] = {
-    val parser: CSVParser = CSVParser.parse(new File(file), Charset.forName(encoding), CSVFormat.DEFAULT.withHeader(fields: _*).withTrim())
+    val parser: CSVParser = CSVParser.parse(new File(file), Charset.forName(encoding), CSVFormat.DEFAULT.withHeader(fields: _*).withTrim().withQuoteMode(QuoteMode.MINIMAL))
     try {
       val dict = Dictionary(
         parser.getRecords().map(
@@ -76,7 +76,7 @@ class SampleCsvDataProcessor(val fields: Seq[String], val data: Seq[String]) ext
       b.append(d)
       b.append(Properties.lineSeparator)
     })
-    val parser: CSVParser = CSVParser.parse(b.toString, CSVFormat.DEFAULT.withHeader(fields: _*).withTrim())
+    val parser: CSVParser = CSVParser.parse(b.toString, CSVFormat.DEFAULT.withHeader(fields: _*).withTrim().withQuoteMode(QuoteMode.MINIMAL))
     try {
       val dict = Dictionary(
         parser.getRecords().map(

--- a/app/org/org/apache/ml/feature/MDLPDiscretizer.scala
+++ b/app/org/org/apache/ml/feature/MDLPDiscretizer.scala
@@ -1,0 +1,226 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.ml.feature
+
+import org.apache.hadoop.fs.Path
+
+import org.apache.spark.annotation.{Experimental, Since}
+import org.apache.spark.ml._
+import org.apache.spark.ml.param._
+import org.apache.spark.ml.param.shared._
+import org.apache.spark.ml.util._
+import org.apache.spark.mllib.feature
+import org.apache.spark.mllib.linalg._
+import org.apache.spark.sql._
+import org.apache.spark.sql.functions._
+import org.apache.spark.sql.types.{StructField, StructType, DoubleType}
+import org.apache.spark.mllib.regression.LabeledPoint
+import org.apache.spark.ml.attribute._
+
+/**
+ * Params for [[MDLPDiscretizer]] and [[DiscretizerModel]].
+ */
+private[feature] trait MDLPDiscretizerParams extends Params with HasInputCol with HasOutputCol with HasLabelCol {
+
+  /**
+   * Maximum number of buckets into which data points are grouped. 
+   * Must be >= 2. default: 2
+   * @group param
+   */
+  val maxBins = new IntParam(this, "maxBins", "Maximum number of bins" +
+    "into which data points are grouped. Must be >= 2.",
+    ParamValidators.gtEq(2))
+  setDefault(maxBins -> 2)
+
+  /** @group getParam */
+  def getMaxBins: Int = getOrDefault(maxBins)
+  
+    /**
+   * Maximum number of elements to evaluate in each partition. 
+   * If this parameter is bigger then the evaluation phase will be sequentially performed. 
+   * Must be >= 10,000.
+   * default: 10,000
+   * @group param
+   */
+  val maxByPart = new IntParam(this, "maxByPart", "Maximum number of elements per partition" +
+    "to considere in each evaluation process. Must be >= 10,000.",
+    ParamValidators.gtEq(10000))
+  setDefault(maxByPart -> 10000)
+
+  /** @group getParam */
+  def getMaxByPart: Int = getOrDefault(maxByPart)
+
+}
+
+/**
+ * :: Experimental ::
+ * MDLPDiscretizer trains a model to discretize vectors using a matrix of buckets (different values for aech feature).
+ */
+@Experimental
+class MDLPDiscretizer (override val uid: String) extends Estimator[DiscretizerModel] with MDLPDiscretizerParams
+  with DefaultParamsWritable {
+  
+  def this() = this(Identifiable.randomUID("MDLPDiscretizer"))
+
+  /** @group setParam */
+  def setMaxBins(value: Int): this.type = set(maxBins, value)
+  
+  /** @group setParam */
+  def setMaxByPart(value: Int): this.type = set(maxByPart, value)
+
+  /** @group setParam */
+  def setInputCol(value: String): this.type = set(inputCol, value)
+
+  /** @group setParam */
+  def setOutputCol(value: String): this.type = set(outputCol, value)
+  
+  /** @group setParam */
+  def setLabelCol(value: String): this.type = set(labelCol, value)
+
+  /**
+   * Computes a [[DiscretizerModel]] that contains the cut points (splits) for each input feature.
+   */
+  override def fit(dataset: DataFrame): DiscretizerModel = {
+    transformSchema(dataset.schema, logging = true)
+    val input = dataset.select($(labelCol), $(inputCol)).map {
+      case Row(label: Double, features: Vector) =>
+        LabeledPoint(label, features)
+    }
+    val discretizer = feature.MDLPDiscretizer.train(input, None, $(maxBins), $(maxByPart))
+    copyValues(new DiscretizerModel(uid, discretizer.thresholds).setParent(this))
+  }
+  
+  override def transformSchema(schema: StructType): StructType = {
+    validateParams()
+    val inputType = schema($(inputCol)).dataType
+    require(inputType.isInstanceOf[VectorUDT],
+      s"Input column ${$(inputCol)} must be a vector column")
+    require(!schema.fieldNames.contains($(outputCol)),
+      s"Output column ${$(outputCol)} already exists.")
+    val outputFields = schema.fields :+ StructField($(outputCol), new VectorUDT, false)
+    StructType(outputFields)
+  }
+  
+  override def copy(extra: ParamMap): MDLPDiscretizer = defaultCopy(extra)
+}
+
+@Since("1.6.0")
+object MDLPDiscretizer extends DefaultParamsReadable[MDLPDiscretizer] {
+
+  @Since("1.6.0")
+  override def load(path: String): MDLPDiscretizer = super.load(path)
+}
+
+/**
+ * :: Experimental ::
+ * Model fitted by [[MDLPDiscretizer]].
+ *
+ * @param splits Splits organized by feature. Each column is the list of splits for a single feature.
+ */
+@Experimental
+class DiscretizerModel private[ml] (
+    override val uid: String,
+    val splits: Array[Array[Float]])
+  extends Model[DiscretizerModel] with MDLPDiscretizerParams with MLWritable {
+  
+  import DiscretizerModel._
+
+  /** @group setParam */
+  def setInputCol(value: String): this.type = set(inputCol, value)
+
+  /** @group setParam */
+  def setOutputCol(value: String): this.type = set(outputCol, value)
+
+  /**
+   * Transform a vector to the discrete space determined by the splits.
+   * NOTE: Vectors to be transformed must be the same length
+   * as the source vectors given to [[MDLPDiscretizer.fit()]].
+   */
+  override def transform(dataset: DataFrame): DataFrame = {
+    transformSchema(dataset.schema, logging = true)
+    val discModel = new feature.DiscretizerModel(splits)
+    val discOp = udf { discModel.transform _ }
+    dataset.withColumn($(outputCol), discOp(col($(inputCol))))
+  }
+
+  override def transformSchema(schema: StructType): StructType = {
+    validateParams()
+    val buckets = splits.map(_.sliding(2).map(bucket => bucket.mkString(", ")).toArray)
+    val featureAttributes: Seq[attribute.Attribute] = for(i <- 0 until splits.length) yield new NominalAttribute(
+        isOrdinal = Some(true),
+        values = Some(buckets(i)))
+    val newAttributeGroup = new AttributeGroup($(outputCol), featureAttributes.toArray)
+    val outputFields = schema.fields :+ newAttributeGroup.toStructField()
+    StructType(outputFields)
+  }
+
+  override def copy(extra: ParamMap): DiscretizerModel = {
+    val copied = new DiscretizerModel(uid, splits)
+    copyValues(copied, extra).setParent(parent)
+  }
+
+  @Since("1.6.0")
+  override def write: MLWriter = new DiscretizerModelWriter(this)
+}
+
+
+@Since("1.6.0")
+object DiscretizerModel extends MLReadable[DiscretizerModel] {
+
+  private[DiscretizerModel] class DiscretizerModelWriter(instance: DiscretizerModel) extends MLWriter {
+
+    private case class Data(splits: Array[Array[Float]])
+
+    override protected def saveImpl(path: String): Unit = {
+      DefaultParamsWriter.saveMetadata(instance, path, sc)
+      val data = Data(instance.splits)
+      val dataPath = new Path(path, "data").toString
+      sqlContext.createDataFrame(Seq(data)).repartition(1).write.parquet(dataPath)
+    }
+  }
+
+  private class DiscretizerModelReader extends MLReader[DiscretizerModel] {
+
+    private val className = classOf[DiscretizerModel].getName
+
+    /**
+     * Loads a [[DiscretizerModel]] from data located at the input path. A model
+     * can be loaded from such older data (a bi-dim matrix of splits).
+     *
+     * @param path path to serialized model data
+     * @return a [[DiscretizerModel]]
+     */
+    override def load(path: String): DiscretizerModel = {
+      val metadata = DefaultParamsReader.loadMetadata(path, sc, className)
+      val dataPath = new Path(path, "data").toString
+      val Row(splits: Array[Array[Float]]) =
+          sqlContext.read.parquet(dataPath)
+            .select("splits")
+            .head()
+      val model = new DiscretizerModel(metadata.uid, splits)
+      DefaultParamsReader.getAndSetParams(model, metadata)
+      model
+    }
+  }
+
+  @Since("1.6.0")
+  override def read: MLReader[DiscretizerModel] = new DiscretizerModelReader
+
+  @Since("1.6.0")
+  override def load(path: String): DiscretizerModel = super.load(path)
+}

--- a/app/org/org/apache/mllib/feature/DiscretizerModel.scala
+++ b/app/org/org/apache/mllib/feature/DiscretizerModel.scala
@@ -1,0 +1,108 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.mllib.feature
+
+import org.apache.spark.mllib.regression.LabeledPoint
+import org.apache.spark.rdd.RDD
+import org.apache.spark.mllib.linalg._
+import scala.collection.immutable.TreeSet
+
+/**
+ * Generic a discretizer model that transform data given a list of thresholds by feature.
+ * 
+ * @param thresholds Thresholds defined for each feature (must be sorted).
+ *  
+ * Note: checking the second sorting condition can be much more time-consuming. 
+ * We omit this condition.
+ */
+class DiscretizerModel (val thresholds: Array[Array[Float]]) extends VectorTransformer {
+  
+  /**
+   * Discretizes values in a given dataset using thresholds.
+   *
+   * @param data A single continuous-valued vector.
+   * @return A resulting vector with its values discretized (from 1 to n).
+   */
+  override def transform(data: Vector) = {
+    data match {
+      case v: SparseVector =>
+        val newValues = for (i <- 0 until v.indices.length) 
+          yield assignDiscreteValue(v.values(i).toFloat, thresholds(v.indices(i))).toDouble
+        
+        // the `index` array inside sparse vector object will not be changed,
+        // so we can re-use it to save memory.
+        Vectors.sparse(v.size, v.indices, newValues.toArray)
+        
+        case v: DenseVector =>
+          val newValues = for (i <- 0 until v.values.length)
+            yield assignDiscreteValue(v(i).toFloat, thresholds(i)).toDouble         
+          Vectors.dense(newValues.toArray)
+    }    
+  } 
+  
+  /**
+   * Discretizes values in a given dataset using thresholds.
+   *
+   * @param data RDD with continuous-valued vectors.
+   * @return RDD with discretized data (from 1 to n).
+   */
+  def transformRDD(data: RDD[Vector]) = {
+    val bc_thresholds = data.context.broadcast(thresholds)    
+    data.map {
+      case v: SparseVector =>
+        val newValues = for (i <- 0 until v.indices.length) 
+          yield assignDiscreteValue(v.values(i).toFloat, bc_thresholds.value(v.indices(i))).toDouble
+        
+        // the `index` array inside sparse vector object will not be changed,
+        // so we can re-use it to save memory.
+        Vectors.sparse(v.size, v.indices, newValues.toArray)
+        
+        case v: DenseVector =>
+          val newValues = for (i <- 0 until v.values.length)
+            yield assignDiscreteValue(v(i).toFloat, bc_thresholds.value(i)).toDouble         
+          Vectors.dense(newValues.toArray)
+    }
+  }
+  
+  private def binarySearch[A <% Ordered[A]](a: Array[A], v: A) = {
+    def recurse(low: Int, high: Int): Int = (low + high) / 2 match {
+      case _ if high < low => high + 1
+      case mid if a(mid) > v => recurse(low, mid - 1)
+      case mid if a(mid) < v => recurse(mid + 1, high)
+      case mid => mid
+    }
+    recurse(0, a.size - 1)
+  }
+
+  /**
+   * Discretizes a value with a set of intervals.
+   *
+   * @param value Value to be discretized.
+   * @param thresholds Thresholds used to assign a discrete value
+   * 
+   * Note: The last threshold must be always Positive Infinity
+   */
+  private def assignDiscreteValue(value: Float, thresholds: Array[Float]) = {
+    if(thresholds.length > 0) {
+      binarySearch(thresholds, value)
+    } else {
+      value
+    }
+  }
+
+}

--- a/app/org/org/apache/mllib/feature/FeatureUtils.scala
+++ b/app/org/org/apache/mllib/feature/FeatureUtils.scala
@@ -1,0 +1,74 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.mllib.feature
+
+import scala.collection.mutable.ArrayBuilder
+
+import org.apache.spark.annotation.Experimental
+import org.apache.spark.mllib.linalg._
+
+/**
+ * Feature utils object for selector methods.
+ *  
+ */
+
+@Experimental
+object FeatureUtils {
+  /**
+   * Returns a vector with features filtered.
+   * Preserves the order of filtered features the same as their indices are stored.
+   * Might be moved to Vector as .slice
+   * @param features vector
+   * @param filterIndices indices of features to filter, must be ordered asc
+   */
+  private[feature] def compress(features: Vector, filterIndices: Array[Int]): Vector = {
+    features match {
+      case v: SparseVector =>
+        val newSize = filterIndices.length
+        val newValues = new ArrayBuilder.ofDouble
+        val newIndices = new ArrayBuilder.ofInt
+        var i = 0
+        var j = 0
+        var indicesIdx = 0
+        var filterIndicesIdx = 0
+        while (i < v.indices.length && j < filterIndices.length) {
+          indicesIdx = v.indices(i)
+          filterIndicesIdx = filterIndices(j)
+          if (indicesIdx == filterIndicesIdx) {
+            newIndices += j
+            newValues += v.values(i)
+            j += 1
+            i += 1
+          } else {
+            if (indicesIdx > filterIndicesIdx) {
+              j += 1
+            } else {
+              i += 1
+            }
+          }
+        }
+        // TODO: Sparse representation might be ineffective if (newSize ~= newValues.size)
+        Vectors.sparse(newSize, newIndices.result(), newValues.result())
+      case v: DenseVector =>
+        Vectors.dense(filterIndices.map(i => v.values(i)))
+      case other =>
+        throw new UnsupportedOperationException(
+          s"Only sparse and dense vectors are supported but got ${other.getClass}.")
+    }
+  }
+}

--- a/app/org/org/apache/mllib/feature/MDLPDiscretizer.scala
+++ b/app/org/org/apache/mllib/feature/MDLPDiscretizer.scala
@@ -1,0 +1,494 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.mllib.feature
+
+import scala.collection.mutable
+
+import breeze.linalg.{SparseVector => BSV}
+
+import org.apache.spark.SparkContext._ 
+import org.apache.spark.storage.StorageLevel
+import org.apache.spark.Logging
+import org.apache.spark.rdd._
+import org.apache.spark.mllib.regression.LabeledPoint
+import org.apache.spark.mllib.linalg._
+
+/**
+ * Entropy minimization discretizer based on Minimum Description Length Principle (MDLP)
+ * proposed by Fayyad and Irani in 1993 [1].
+ * 
+ * [1] Fayyad, U., & Irani, K. (1993). 
+ * "Multi-interval discretization of continuous-valued attributes for classification learning."
+ *
+ * @param data RDD of LabeledPoint
+ * 
+ */
+class MDLPDiscretizer private (val data: RDD[LabeledPoint]) extends Serializable with Logging {
+
+  private val log2 = { x: Double => math.log(x) / math.log(2) }  
+  private def entropy(freqs: Seq[Long], n: Long) = {
+    // val n = freqs.reduce(_ + _)
+    freqs.aggregate(0.0)({ case (h, q) =>
+      h + (if (q == 0) 0  else (q.toDouble / n) * (math.log(q.toDouble / n) / math.log(2)))
+    }, { case (h1, h2) => h1 + h2 }) * -1
+  }
+  
+  private val isBoundary = (f1: Array[Long], f2: Array[Long]) => {
+    (f1, f2).zipped.map(_ + _).filter(_ != 0).size > 1
+  }
+  private val maxLimitBins = Byte.MaxValue - Byte.MinValue + 1
+  private val labels2Int = data.map(_.label).distinct.collect.zipWithIndex.toMap
+  private val nLabels = labels2Int.size
+  
+  /**
+   * Get information about the attributes before performing discretization.
+   * 
+   * @param contIndices Indexes to discretize (if not specified, they are calculated).
+   * @param nFeatures Total number of input features.
+   * @return Indexes of continuous features.
+   * 
+   */  
+  private def processContinuousAttributes(
+      contIndices: Option[Seq[Int]], 
+      nFeatures: Int) = {
+    contIndices match {
+      case Some(s) => 
+        // Attributes are in range 0..nfeat
+        val intersect = (0 until nFeatures).seq.intersect(s)
+        require(intersect.size == s.size)
+        s.toArray
+      case None =>
+        (0 until nFeatures).toArray
+    }
+  }
+  
+  /**
+   * Computes the initial candidate points by feature.
+   * 
+   * @param points RDD with distinct points by feature ((feature, point), class values).
+   * @param firstElements First elements in partitions 
+   * @return RDD of candidate points.
+   * 
+   */
+  private def initialThresholds(
+      points: RDD[((Int, Float), Array[Long])], 
+      firstElements: Array[Option[(Int, Float)]]) = {
+    
+    val numPartitions = points.partitions.length
+    val bcFirsts = points.context.broadcast(firstElements)      
+
+    points.mapPartitionsWithIndex({ (index, it) =>      
+      if(it.hasNext) {  
+        var ((lastK, lastX), lastFreqs) = it.next()
+        var result = Seq.empty[((Int, Float), Array[Long])]
+        var accumFreqs = lastFreqs      
+        
+        for (((k, x), freqs) <- it) {           
+          if(k != lastK) {
+            // new attribute: add last point from the previous one
+            result = ((lastK, lastX), accumFreqs.clone) +: result
+            accumFreqs = Array.fill(nLabels)(0L)
+          } else if(isBoundary(freqs, lastFreqs)) {
+            // new boundary point: midpoint between this point and the previous one
+            result = ((lastK, (x + lastX) / 2), accumFreqs.clone) +: result
+            accumFreqs = Array.fill(nLabels)(0L)
+          }
+          
+          lastK = k
+          lastX = x
+          lastFreqs = freqs
+          accumFreqs = (accumFreqs, freqs).zipped.map(_ + _)
+        }
+       
+        // Evaluate the last point in this partition with the first one in the next partition
+        val lastPoint = if(index < (numPartitions - 1)) {
+          bcFirsts.value(index + 1) match {
+            case Some((k, x)) => if(k != lastK) lastX else (x + lastX) / 2 
+            case None => lastX // last point in the attribute
+          }
+        }else{
+            lastX // last point in the dataset
+        }                    
+        (((lastK, lastPoint), accumFreqs.clone) +: result).reverse.toIterator
+      } else {
+        Iterator.empty
+      }             
+    })
+  }
+  
+  /**
+   * Evaluate boundary points and select the most relevant. This version is used when 
+   * the number of candidates exceeds the maximum size per partition (distributed version).
+   * 
+   * @param candidates RDD of candidates points (point, class histogram).
+   * @param maxBins Maximum number of points to select
+   * @param elementsByPart Maximum number of elements to evaluate in each partition.
+   * @return Sequence of threshold values.
+   * 
+   */
+  private def getThresholds(
+      candidates: RDD[(Float, Array[Long])],
+      maxBins: Int, 
+      elementsByPart: Int) = {
+
+    // Get the number of partitions according to the maximum size established by partition
+    val partitions = { x: Long => math.ceil(x.toFloat / elementsByPart).toInt }    
+    
+    // Insert the extreme values in the stack (recursive iteration)
+    val stack = new mutable.Queue[((Float, Float), Option[Float])]
+    stack.enqueue(((Float.NegativeInfinity, Float.PositiveInfinity), None))
+    var result = Seq.empty[Float]
+    val maxPoints = maxBins + 1
+
+    while(stack.length > 0 && result.size < maxPoints){
+      val (bounds, lastThresh) = stack.dequeue
+      // Filter the candidates between the last limits added to the stack
+      var cands = candidates.filter({ case (th, _) => th > bounds._1 && th < bounds._2 })
+      val nCands = cands.count
+      if (nCands > 0) {
+        cands = cands.coalesce(partitions(nCands))
+        // Selects one threshold among the candidates and returns two partitions to recurse
+        evalThresholds(cands, lastThresh) match {
+          case Some(th) =>
+            result = th +: result
+            stack.enqueue(((bounds._1, th), Some(th)))
+            stack.enqueue(((th, bounds._2), Some(th)))
+          case None => /* criteria not fulfilled, finish! */
+        }
+      }
+    }
+    result.sorted :+ Float.PositiveInfinity
+  }
+  
+  /**
+   * Evaluates boundary points and selects the most relevant candidates (sequential version).
+   * Here, the evaluation is bounded by partition as the number of points is small enough.
+   * 
+   * @param candidates RDD of candidates points (point, class histogram).
+   * @param maxBins Maximum number of points to select.
+   * @return Sequence of threshold values.
+   * 
+   */
+  private def getThresholds(candidates: Array[(Float, Array[Long])], maxBins: Int) = {
+
+    val stack = new mutable.Queue[((Float, Float), Option[Float])]
+    // Insert first in the stack (recursive iteration)
+    stack.enqueue(((Float.NegativeInfinity, Float.PositiveInfinity), None))
+    var result = Seq.empty[Float]
+    val maxPoints = maxBins + 1
+
+    while(stack.length > 0 && result.size < maxPoints){
+      val (bounds, lastThresh) = stack.dequeue
+      // Filter the candidates between the last limits added to the stack
+      val newCandidates = candidates.filter({ case (th, _) => 
+          th > bounds._1 && th < bounds._2 
+        })      
+      if (newCandidates.size > 0) {
+        evalThresholds(newCandidates, lastThresh, nLabels) match {
+          case Some(th) =>
+            result = th +: result
+            stack.enqueue(((bounds._1, th), Some(th)))
+            stack.enqueue(((th, bounds._2), Some(th)))
+          case None => /* criteria not fulfilled, finish */
+        }
+      }
+    }
+    result.sorted :+ Float.PositiveInfinity
+  }
+
+  /**
+   * Compute entropy minimization for candidate points in a range,
+   * and select the best one according to the MDLP criterion (RDD version).
+   * 
+   * @param candidates RDD of candidate points (point, class histogram).
+   * @param lastSelected Last selected threshold.
+   * @return The minimum-entropy candidate.
+   * 
+   */
+  private def evalThresholds(
+      candidates: RDD[(Float, Array[Long])],
+      lastSelected : Option[Float]) = {
+
+    val numPartitions = candidates.partitions.size
+    val sc = candidates.sparkContext
+
+    // Compute the accumulated frequencies by partition
+    val totalsByPart = sc.runJob(candidates, { case it =>
+      val accum = Array.fill(nLabels)(0L)
+      for ((_, freqs) <- it) {for (i <- 0 until nLabels) accum(i) += freqs(i)}
+      accum
+    }: (Iterator[(Float, Array[Long])]) => Array[Long])
+    
+    // Compute the total frequency for all partitions
+    var totals = Array.fill(nLabels)(0L)
+    for (t <- totalsByPart) totals = (totals, t).zipped.map(_ + _)
+    val bcTotalsByPart = sc.broadcast(totalsByPart)
+    val bcTotals = sc.broadcast(totals)
+
+    val result = candidates.mapPartitionsWithIndex({ (slice, it) =>
+      // Accumulate frequencies from the left to the current partition
+      var leftTotal = Array.fill(nLabels)(0L)
+      for (i <- 0 until slice) leftTotal = (leftTotal, bcTotalsByPart.value(i)).zipped.map(_ + _)
+      var entropyFreqs = Seq.empty[(Float, Array[Long], Array[Long], Array[Long])]
+      // ... and from the current partition to the rightmost partition
+      for ((cand, freqs) <- it) {
+        leftTotal = (leftTotal, freqs).zipped.map(_ + _)
+        val rightTotal = (bcTotals.value, leftTotal).zipped.map(_ - _)
+        entropyFreqs = (cand, freqs, leftTotal.clone, rightTotal) +: entropyFreqs
+      }        
+      entropyFreqs.iterator
+    })
+
+    // calculate h(S)
+    // s: number of elements
+    // k: number of distinct classes
+    // hs: entropy        
+    val s  = totals.sum
+    val hs = entropy(totals.toSeq, s)
+    val k  = totals.filter(_ != 0).size
+
+    // select the best threshold according to MDLP
+    val finalCandidates = result.flatMap({
+      case (cand, _, leftFreqs, rightFreqs) =>
+        val k1 = leftFreqs.filter(_ != 0).size; val s1 = leftFreqs.sum
+        val hs1 = entropy(leftFreqs, s1)
+        val k2 = rightFreqs.filter(_ != 0).size; val s2 = rightFreqs.sum
+        val hs2 = entropy(rightFreqs, s2)
+        val weightedHs = (s1 * hs1 + s2 * hs2) / s
+        val gain = hs - weightedHs
+        val delta = log2(math.pow(3, k) - 2) - (k * hs - k1 * hs1 - k2 * hs2)
+        var criterion = (gain - (log2(s - 1) + delta) / s) > -1e-5
+        lastSelected match {
+          case None =>
+          case Some(last) => criterion = criterion && (cand != last)
+        }
+        if (criterion) Seq((weightedHs, cand)) else Seq.empty[(Double, Float)]
+    })
+    // Select among the list of accepted candidate, that with the minimum weightedHs
+    if (finalCandidates.count > 0) Some(finalCandidates.min._2) else None
+  }
+  
+  /**
+   * Compute entropy minimization for candidate points in a range,
+   * and select the best one according to MDLP criterion (sequential version).
+   * 
+   * @param candidates Array of candidate points (point, class histogram).
+   * @param lastSelected last selected threshold.
+   * @param nLabels Number of classes.
+   * @return The minimum-entropy cut point.
+   * 
+   */
+  private def evalThresholds(
+      candidates: Array[(Float, Array[Long])],
+      lastSelected : Option[Float],
+      nLabels: Int): Option[Float] = {
+    
+    // Calculate the total frequencies by label
+    val totals = candidates.map(_._2).reduce((freq1, freq2) => (freq1, freq2).zipped.map(_ + _))
+    
+    // Compute the accumulated frequencies (both left and right) by label
+    var leftAccum = Array.fill(nLabels)(0L)
+    var entropyFreqs = Seq.empty[(Float, Array[Long], Array[Long], Array[Long])]
+    for(i <- 0 until candidates.size) {
+      val (cand, freq) = candidates(i)
+      leftAccum = (leftAccum, freq).zipped.map(_ + _)
+      val rightTotal = (totals, leftAccum).zipped.map(_ - _)
+      entropyFreqs = (cand, freq, leftAccum.clone, rightTotal) +: entropyFreqs
+    }
+
+    // calculate h(S)
+    // s: number of elements
+    // k: number of distinct classes
+    // hs: entropy
+    val s = totals.sum
+    val hs = entropy(totals.toSeq, s)
+    val k = totals.filter(_ != 0).size
+
+    // select best threshold according to the criteria
+    val finalCandidates = entropyFreqs.flatMap({
+      case (cand, _, leftFreqs, rightFreqs) =>
+        val k1 = leftFreqs.filter(_ != 0).size
+        val s1 = if (k1 > 0) leftFreqs.sum else 0
+        val hs1 = entropy(leftFreqs, s1)
+        val k2 = rightFreqs.filter(_ != 0).size
+        val s2 = if (k2 > 0) rightFreqs.sum else 0
+        val hs2 = entropy(rightFreqs, s2)
+        val weightedHs = (s1 * hs1 + s2 * hs2) / s
+        val gain = hs - weightedHs
+        val delta = log2(math.pow(3, k) - 2) - (k * hs - k1 * hs1 - k2 * hs2)
+        var criterion = (gain - (log2(s - 1) + delta) / s) > -1e-5
+        
+        lastSelected match {
+            case None =>
+            case Some(last) => criterion = criterion && (cand != last)
+        }
+
+        if (criterion) Seq((weightedHs, cand)) else Seq.empty[(Double, Float)]
+    })
+    // Select among the list of accepted candidate, that with the minimum weightedHs
+    if (finalCandidates.size > 0) Some(finalCandidates.min._2) else None
+  }
+ 
+  /**
+   * Run the entropy minimization discretizer on input data.
+   * 
+   * @param contFeat Indices to discretize (if not specified, the algorithm try to figure it out).
+   * @param elementsByPart Maximum number of elements to keep in each partition.
+   * @param maxBins Maximum number of thresholds per feature.
+   * @return A discretization model with the thresholds by feature.
+   * 
+   */
+  def runAll(
+      contFeat: Option[Seq[Int]], 
+      elementsByPart: Int,
+      maxBins: Int) = {
+    
+    if (data.getStorageLevel == StorageLevel.NONE) {
+      logWarning("The input data is not directly cached, which may hurt performance if its"
+        + " parent RDDs are also uncached.")
+    }
+
+    // Basic info. about the dataset
+    val sc = data.context; val nInstances = data.count
+    val bLabels2Int = sc.broadcast(labels2Int)
+    val classDistrib = data.map(d => bLabels2Int.value(d.label)).countByValue()
+    val bclassDistrib = sc.broadcast(classDistrib)
+    val (dense, nFeatures) = data.first.features match {
+      case v: DenseVector => 
+        (true, v.size)
+      case v: SparseVector =>
+        (false, v.size)
+    }
+            
+    val continuousVars = processContinuousAttributes(contFeat, nFeatures)
+    logInfo("Number of continuous attributes: " + continuousVars.distinct.size)
+    logInfo("Total number of attributes: " + nFeatures)      
+    if(continuousVars.isEmpty) logWarning("Discretization aborted. " +
+      "No continous attribute in the dataset")
+    
+    // Generate pairs ((feature, point), class histogram)
+    val featureValues = dense match {
+      case true => 
+        val bContinuousVars = sc.broadcast(continuousVars)
+        data.flatMap({ case LabeledPoint(label, dv: DenseVector) =>            
+            val c = Array.fill[Long](nLabels)(0L)
+            c(bLabels2Int.value(label)) = 1L
+            for(i <- 0 until dv.values.length) yield ((i, dv(i).toFloat), c)                  
+        })
+      case false =>
+        val bContVars = sc.broadcast(continuousVars)          
+        data.flatMap{ case LabeledPoint(label, sv: SparseVector) =>
+          val c = Array.fill[Long](nLabels)(0L)
+          c(bLabels2Int.value(label)) = 1L
+          for(i <- 0 until sv.indices.length) yield ((sv.indices(i), sv.values(i).toFloat), c)
+        }
+    }
+    
+    // Group elements by feature and point (get distinct points)
+    val nonzeros = featureValues.reduceByKey{ case (v1, v2) => 
+      (v1, v2).zipped.map(_ + _)
+    }
+      
+    // Add zero elements for sparse data
+    val zeros = nonzeros
+      .map{case ((k, p), v) => (k, v)}
+      .reduceByKey{ case (v1, v2) =>  (v1, v2).zipped.map(_ + _)}
+      .map{ case (k, v) => 
+        val v2 = for(i <- 0 until v.length) yield bclassDistrib.value(i) - v(i)
+        ((k, 0.0F), v2.toArray)
+      }.filter{case (_, v) => v.sum > 0}
+    val distinctValues = nonzeros.union(zeros)
+    
+    // Sort these values to perform the boundary points evaluation
+    val sortedValues = distinctValues.sortByKey()
+          
+    // Get the first elements by partition for the boundary points evaluation
+    val firstElements = sc.runJob(sortedValues, { case it =>
+      if (it.hasNext) Some(it.next()._1) else None
+    }: (Iterator[((Int, Float), Array[Long])]) => Option[(Int, Float)])
+      
+    // Filter those features selected by the user
+    val arr = Array.fill(nFeatures) { false }
+    continuousVars.map(arr(_) = true)
+    val barr = sc.broadcast(arr)
+    
+    // Get only boundary points from the whole set of distinct values
+    val initialCandidates = initialThresholds(sortedValues, firstElements)
+      .map{case ((k, point), c) => (k, (point, c))}
+      .filter({case (k, _) => barr.value(k)})
+      .cache() // It will be iterated for "big" features
+      
+    // Divide RDD into two categories according to the number of points by feature
+    val bigIndexes = initialCandidates
+      .countByKey()
+      .filter{case (_, c) => c > elementsByPart}
+    val bBigIndexes = sc.broadcast(bigIndexes)
+      
+    // The features with a small number of points can be processed in a parallel way
+    val smallThresholds = initialCandidates
+      .filter{case (k, _) => !bBigIndexes.value.contains(k) }
+      .groupByKey()
+      .mapValues(_.toArray)
+      .mapValues(points => getThresholds(points.toArray.sortBy(_._1), maxBins))
+    
+    // Feature with too many points must be processed iteratively (rare condition)
+    logInfo("Number of features that exceed the maximum size per partition: " + 
+        bigIndexes.size)
+    var bigThresholds = Map.empty[Int, Seq[Float]]
+    for (k <- bigIndexes.keys){ 
+      val cands = initialCandidates.filter{case (k2, _) => k == k2}.values.sortByKey()
+      bigThresholds += ((k, getThresholds(cands, maxBins, elementsByPart)))
+    }
+
+    // Join all thresholds in a single structure
+    val bigThRDD = sc.parallelize(bigThresholds.toSeq)
+    val thrs = smallThresholds.union(bigThRDD).collect()
+    
+    // Update the full list features with the thresholds calculated
+    val thresholds = Array.fill(nFeatures)(Array.empty[Float])   // Nominal values (empty)
+    continuousVars.map(f => thresholds(f) = Array(Float.PositiveInfinity)) // Not processed continuous attributes
+    thrs.foreach({case (k, vth) => 
+      thresholds(k) = if(arr.length > 0) vth.toArray else Array(Float.PositiveInfinity)}) // Continuous attributes (> 0 cut point)    
+    logInfo("Number of features with thresholds computed: " + thrs.length)
+    
+    new DiscretizerModel(thresholds)
+  }
+}
+
+object MDLPDiscretizer {
+
+  /**
+   * Train a entropy minimization discretizer given an RDD of LabeledPoints.
+   * 
+   * @param input RDD of LabeledPoint's.
+   * @param continuousFeaturesIndexes Indexes of features to be discretized. 
+   * If it is not provided, the algorithm selects those features with more than 
+   * 256 (byte range) distinct values.
+   * @param maxBins Maximum number of thresholds to select per feature.
+   * @param maxByPart Maximum number of elements by partition.
+   * @return A DiscretizerModel with the subsequent thresholds.
+   * 
+   */
+  def train(
+      input: RDD[LabeledPoint],
+      continuousFeaturesIndexes: Option[Seq[Int]] = None,
+      maxBins: Int = 15,
+      maxByPart: Int = 100000) = {
+    new MDLPDiscretizer(input).runAll(continuousFeaturesIndexes, maxByPart, maxBins)
+  }
+}

--- a/examples/example-kea-extract.conf
+++ b/examples/example-kea-extract.conf
@@ -1,0 +1,44 @@
+{
+  dictionary : [
+    {
+      class : org.nlp4l.framework.builtin.GenericDictionaryAttributeFactory
+      settings : {
+        name: "KEA.ExtractKeyphrasesResultDict"
+        attributes : [
+          { name: "docId" }
+          { name: "keyphrases" }
+          { name: "text" }
+        ]
+      }
+    }
+  ]
+
+  processors : [
+    {
+      class : org.nlp4l.sample.SampleCsvDataProcessorFactory
+      settings : {
+        fields: [
+          "docId",
+          "text"
+        ],
+        data: [
+          "DOC-001, Cloud computing is internet based network. Internet is ... Cloud computing brings us ... internet world."
+          "DOC-002, Cloud storage is internet based storage. Cloud storage stores data on the internet."
+          "DOC-003, run out of memory. run out of memory. term freq is two."
+          "DOC-004, run out of memory. term freq is one."
+        ]
+      }
+    }
+    {
+      class : org.nlp4l.framework.builtin.kea.KeyphraseExtractionProcessorFactory
+      settings : {
+        idField:     "docId"
+        textField:   "text"
+        modelDir:    "/opt/nlp4l/example-kea"
+        passThruFields: [
+          "text"
+        ]
+      }
+    }
+  ]
+}

--- a/examples/example-kea-model.conf
+++ b/examples/example-kea-model.conf
@@ -1,0 +1,37 @@
+{
+  dictionary : [
+    {
+      class : org.nlp4l.framework.builtin.GenericDictionaryAttributeFactory
+      settings : {
+        name: "KEA.BuildModelResultDict"
+        attributes : [
+          { name: "result" }
+        ]
+      }
+    }
+  ]
+
+  processors : [
+    {
+      class : org.nlp4l.sample.SampleCsvDataProcessorFactory
+      settings : {
+        fields: [
+          "keyphrases",
+          "text"
+        ],
+        data: [
+          "\"cloud computing,internet\", Cloud computing is internet based network. Internet is ... Cloud computing brings us ... internet world."
+          "out of memory, run out of memory. run out of memory."
+        ]
+      }
+    }
+    {
+      class : org.nlp4l.framework.builtin.kea.KEAModelBuildProcessorFactory
+      settings : {
+        keyphrasesField:  "keyphrases"
+        textField:        "text"
+        modelDir:         "/opt/nlp4l/example-kea"
+      }
+    }
+  ]
+}

--- a/examples/example-lucene-indexing.conf
+++ b/examples/example-lucene-indexing.conf
@@ -15,7 +15,7 @@
 //    {
 //      class : org.nlp4l.sample.SampleCsvImportProcessorFactory
 //      settings : {
-//        file:     "/tmp/sample-input-data.csv"
+//        file:     "/opt/nlp4l/sample-input-data.csv"
 //        encoding: "UTF-8"
 //        fields: [
 //          "docId",
@@ -47,7 +47,7 @@
     {
       class : org.nlp4l.framework.builtin.lucene.LuceneIndexingProcessorFactory
       settings : {
-        index:  "/tmp/iwriter-index"
+        index:  "/opt/nlp4l/iwriter-index"
         deleteAll: true
         optimize: true
         schemaDef: {

--- a/examples/example-opennlp-ner.conf
+++ b/examples/example-opennlp-ner.conf
@@ -20,7 +20,7 @@
 //    {
 //      class : org.nlp4l.sample.SampleCsvImportProcessorFactory
 //      settings : {
-//        file:     "/tmp/ner-input-data.csv"
+//        file:     "/opt/nlp4l/tmp/ner-input-data.csv"
 //        encoding: "UTF-8"
 //        fields: [
 //          "docId",
@@ -55,11 +55,11 @@
         {
           class : org.nlp4l.framework.builtin.ner.OpenNLPNerRecordProcessorFactory
           settings : {
-            sentModel:  "/tmp/models/en-sent.bin"
-            tokenModel: "/tmp/models/en-token.bin"
+            sentModel:  "/opt/nlp4l/models/en-sent.bin"
+            tokenModel: "/opt/nlp4l/models/en-token.bin"
             nerModels: [
-              "/tmp/models/en-ner-person.bin",
-              "/tmp/models/en-ner-location.bin"
+              "/opt/nlp4l/models/en-ner-person.bin",
+              "/opt/nlp4l/models/en-ner-location.bin"
               ]
             nerTypes: [
               "person",

--- a/examples/example-spark-mllib-classification.conf
+++ b/examples/example-spark-mllib-classification.conf
@@ -39,7 +39,7 @@
         textField:      "text"
         idField:        "docId"
         passThruFields: [ "title", "text" ]
-        workingDir:   "/tmp/example-doc-class"
+        modelDir:     "/opt/nlp4l/example-doc-class"
         algorithm:    "NaiveBayes"
         analyzer : {
           class : org.apache.lucene.analysis.standard.StandardAnalyzer

--- a/examples/example-spark-mllib-labeled-point.conf
+++ b/examples/example-spark-mllib-labeled-point.conf
@@ -53,7 +53,7 @@
       settings : {
         labelField:  "classification"
         textField:   "text"
-        workingDir:   "/tmp/example-doc-class"
+        modelDir:    "/opt/nlp4l/example-doc-class"
         analyzer : {
           class : org.apache.lucene.analysis.standard.StandardAnalyzer
         }

--- a/examples/example-spark-mllib-train-model.conf
+++ b/examples/example-spark-mllib-train-model.conf
@@ -15,7 +15,7 @@
     {
       class : org.nlp4l.framework.builtin.spark.mllib.TrainAndModelProcessorFactory
       settings : {
-        workingDir:   "/tmp/example-doc-class"
+        modelDir:     "/opt/nlp4l/example-doc-class"
         algorithm:    "NaiveBayes"
         trainTestRate: 0.7
       }

--- a/test/org/nlp4l/framework/builtin/kea/KEAProcessorsSpec.scala
+++ b/test/org/nlp4l/framework/builtin/kea/KEAProcessorsSpec.scala
@@ -1,0 +1,117 @@
+/*
+ * Copyright 2016 org.NLP4L
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.nlp4l.framework.builtin.kea
+
+import java.io.File
+
+import com.typesafe.config.ConfigFactory
+import org.nlp4l.framework.models.{Record, _}
+import org.specs2.mutable.{BeforeAfter, Specification}
+
+class KEAProcessorsSpec extends Specification with BeforeAfter {
+
+  object TestSettings {
+    val TMP_DIR = System.getProperty("java.io.tmpdir")
+    val TEST_OUT_DIR = new File(TMP_DIR, "nlp4l-kea-test").getAbsolutePath.replace('\\', '/')
+  }
+
+  def before = {
+  }
+
+  def after = {
+  }
+
+  "KEAModelBuildProcessor" should {
+    "execute " in {
+
+      // ------------------------------
+      // KEAModelBuildProcessor
+      // ------------------------------
+      val config = ConfigFactory.parseString(
+        s"""
+           |{
+           | textField:   "text"
+           | keyphrasesField:  "keyphrases"
+           | modelDir:   "${TestSettings.TEST_OUT_DIR}"
+           | analyzer : {
+           |   class: "org.nlp4l.framework.builtin.kea.KEAStandardAnalyzer"
+           |   params {
+           |     stopwords: "is, a, the, of"
+           |   }
+           | }
+           | documentSizeAnalyzer : {
+           |   tokenizer {
+           |     factory : whitespace
+           |   }
+           | }
+           |}
+        """.stripMargin)
+      val proc = new KEAModelBuildProcessorFactory(config).getInstance()
+      val dict = Dictionary(Seq(
+        Record(Seq(
+          Cell("keyphrases", "cloud computing,internet"),
+          Cell("text", "Cloud computing is internet based network. Internet is ... Cloud computing brings us ... internet world."))),
+        Record(Seq(
+          Cell("keyphrases", "out of memory"),
+          Cell("text", "run out of memory. run out of memory. ")))
+      ))
+
+      val result = proc.execute(Some(dict))
+      println(result)
+
+      // ------------------------------
+      // KeyphraseExtractionProcessor
+      // ------------------------------
+      val config2 = ConfigFactory.parseString(
+        s"""
+           |{
+           | idField:   "id"
+           | textField:  "text"
+           | modelDir:   "${TestSettings.TEST_OUT_DIR}"
+           | keyphrasesSep: "|"
+//           | incrementDfDocNum: false
+//           | nGramPriorityOrder: "1,2,3"
+//           | scoreThreshold: 0.1
+//           | maxKeyphrases: 10
+           |}
+        """.stripMargin)
+      val proc2 = new KeyphraseExtractionProcessorFactory(config2).getInstance()
+      val dict2 = Dictionary(Seq(
+        Record(Seq(
+          Cell("id", "DOC-001"),
+          Cell("text", "Cloud computing is internet based network. Internet is ... Cloud computing brings us ... internet world."))),
+        Record(Seq(
+          Cell("id", "DOC-002"),
+          Cell("text", "Cloud storage is internet based storage. Cloud storage stores data on the internet."))),
+        Record(Seq(
+          Cell("id", "DOC-003"),
+          Cell("text", "run out of memory. run out of memory.")))
+      ))
+
+      val result2 = proc2.execute(Some(dict2))
+      println(result2)
+
+      result2.get.recordList.foreach(record =>
+        println("keyphrases=" + record.cellValue("keyphrases").get)
+      )
+
+      true
+    }
+
+  }
+
+}

--- a/test/org/nlp4l/framework/builtin/kea/KEAStandardAnalyzerSpec.scala
+++ b/test/org/nlp4l/framework/builtin/kea/KEAStandardAnalyzerSpec.scala
@@ -1,0 +1,90 @@
+/*
+ * Copyright 2016 org.NLP4L
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.nlp4l.framework.builtin.kea
+
+import com.typesafe.config.ConfigFactory
+import org.apache.lucene.analysis.tokenattributes.CharTermAttribute
+import org.apache.lucene.analysis.{Analyzer, TokenStream}
+import org.specs2.mutable.Specification
+
+class KEAStandardAnalyzerSpec extends Specification {
+
+  "KEAStandardAnalyzer" should {
+    "analyze n=1 " in {
+      val analyzer = new KEAStandardAnalyzer(1, null);
+      val text = "AAA of BBB is CCC DDD"
+      val tokens = getTokens(analyzer, text)
+      tokens.length mustEqual 4
+      tokens(0) mustEqual "aaa"
+      tokens(1) mustEqual "bbb"
+      tokens(2) mustEqual "ccc"
+      tokens(3) mustEqual "ddd"
+    }
+    "analyze n=2 " in {
+      val analyzer = new KEAStandardAnalyzer(2, null);
+      val text = "AAA of BBB is CCC DDD"
+      val tokens = getTokens(analyzer, text)
+      tokens.length mustEqual 1
+      tokens(0) mustEqual "ccc ddd"
+    }
+    "analyze n=3 " in {
+      val analyzer = new KEAStandardAnalyzer(3, null);
+      val text = "AAA of BBB is CCC DDD"
+      val tokens = getTokens(analyzer, text)
+      tokens.length mustEqual 2
+      tokens(0) mustEqual "aaa of bbb"
+      tokens(1) mustEqual "bbb is ccc"
+    }
+    "analyze with stopwords " in {
+      val params = ConfigFactory.parseString("{ stopwords: \"aaa, ccc\" }");
+      val analyzer = new KEAStandardAnalyzer(1, params);
+      val text = "AAA BBB CCC DDD"
+      val tokens = getTokens(analyzer, text)
+      tokens.length mustEqual 2
+      tokens(0) mustEqual "bbb"
+      tokens(1) mustEqual "ddd"
+    }
+    //    "analyze with stopwordsFile " in {
+    //      new PrintWriter("/tmp/kea-stopwords.txt") { println("bbb"); println("ccc"); close }
+    //      val params = ConfigFactory.parseString("{ stopwordsFile: /tmp/kea-stopwords.txt }");
+    //      val analyzer = new KEAStandardAnalyzer(1, params);
+    //      val text = "AAA BBB CCC DDD"
+    //      val tokens = getTokens(analyzer, text)
+    //      tokens.length mustEqual 2
+    //      tokens(0) mustEqual "aaa"
+    //      tokens(1) mustEqual "ddd"
+    //    }
+  }
+
+  def getTokens(analyzer: Analyzer, text: String): Seq[String] = {
+    val stream: TokenStream = analyzer.tokenStream("dummy", text)
+    val charTermAttr = stream.addAttribute(classOf[CharTermAttribute])
+    stream.reset()
+    try {
+      Iterator
+        .continually(stream)
+        .takeWhile(_.incrementToken())
+        .map(_ => charTermAttr.toString)
+        .toVector
+    }
+    finally {
+      stream.end()
+      stream.close()
+    }
+  }
+
+}

--- a/test/org/nlp4l/framework/builtin/spark/mllib/DocumentClassificationAlgoSpec.scala
+++ b/test/org/nlp4l/framework/builtin/spark/mllib/DocumentClassificationAlgoSpec.scala
@@ -61,7 +61,7 @@ class DocumentClassificationAlgoSpec extends Specification with BeforeAfter {
            |{
            | textField:   "text"
            | labelField:  "classification"
-           | workingDir:   "${TestSettings.TEST_OUT_DIR}"
+           | modelDir:   "${TestSettings.TEST_OUT_DIR}"
            | analyzer {
            |   class : org.apache.lucene.analysis.standard.StandardAnalyzer
            | }
@@ -87,7 +87,7 @@ class DocumentClassificationAlgoSpec extends Specification with BeforeAfter {
         new TrainAndModelProcessorFactory(ConfigFactory.parseString(
           s"""
              |{
-             | workingDir:   "${TestSettings.TEST_OUT_DIR}"
+             | modelDir:   "${TestSettings.TEST_OUT_DIR}"
              | algorithm:    "NaiveBayes"
              | algorithmParams {
              |   lambda: 0.9
@@ -104,7 +104,7 @@ class DocumentClassificationAlgoSpec extends Specification with BeforeAfter {
            | passThruFields: [
            |   "title"
            |   ]
-           | workingDir:   "${TestSettings.TEST_OUT_DIR}"
+           | modelDir:   "${TestSettings.TEST_OUT_DIR}"
            |  analyzer {
            |   class : org.apache.lucene.analysis.standard.StandardAnalyzer
            | }
@@ -123,7 +123,7 @@ class DocumentClassificationAlgoSpec extends Specification with BeforeAfter {
         new TrainAndModelProcessorFactory(ConfigFactory.parseString(
           s"""
              |{
-             | workingDir:   "${TestSettings.TEST_OUT_DIR}"
+             | modelDir:   "${TestSettings.TEST_OUT_DIR}"
              | algorithm:    "LogisticRegressionWithLBFGS"
              |}
           """.stripMargin)).getInstance().execute(None)
@@ -136,8 +136,8 @@ class DocumentClassificationAlgoSpec extends Specification with BeforeAfter {
            | passThruFields: [
            |   "title"
            |   ]
-           | workingDir:   "${TestSettings.TEST_OUT_DIR}"
-           |  analyzer {
+           | modelDir:   "${TestSettings.TEST_OUT_DIR}"
+           | analyzer {
            |   class : org.apache.lucene.analysis.standard.StandardAnalyzer
            | }
            | algorithm:    "LogisticRegressionWithLBFGS"
@@ -155,7 +155,7 @@ class DocumentClassificationAlgoSpec extends Specification with BeforeAfter {
         new TrainAndModelProcessorFactory(ConfigFactory.parseString(
           s"""
              |{
-             | workingDir:   "${TestSettings.TEST_OUT_DIR}"
+             | modelDir:   "${TestSettings.TEST_OUT_DIR}"
              | algorithm:    "DecisionTree"
              | algorithmParams {
              |   impurity: "gini"
@@ -173,8 +173,8 @@ class DocumentClassificationAlgoSpec extends Specification with BeforeAfter {
            | passThruFields: [
            |   "title"
            |   ]
-           | workingDir:   "${TestSettings.TEST_OUT_DIR}"
-           |  analyzer {
+           | modelDir:   "${TestSettings.TEST_OUT_DIR}"
+           | analyzer {
            |   class : org.apache.lucene.analysis.standard.StandardAnalyzer
            | }
            | algorithm:    "DecisionTree"
@@ -192,7 +192,7 @@ class DocumentClassificationAlgoSpec extends Specification with BeforeAfter {
         new TrainAndModelProcessorFactory(ConfigFactory.parseString(
           s"""
              |{
-             | workingDir:   "${TestSettings.TEST_OUT_DIR}"
+             | modelDir:   "${TestSettings.TEST_OUT_DIR}"
              | algorithm:    "RandomForest"
              | algorithmParams {
              |   numTrees: 9
@@ -212,8 +212,8 @@ class DocumentClassificationAlgoSpec extends Specification with BeforeAfter {
            | passThruFields: [
            |   "title"
            |   ]
-           | workingDir:   "${TestSettings.TEST_OUT_DIR}"
-           |  analyzer {
+           | modelDir:   "${TestSettings.TEST_OUT_DIR}"
+           | analyzer {
            |   class : org.apache.lucene.analysis.standard.StandardAnalyzer
            | }
            | algorithm:    "RandomForest"

--- a/test/org/nlp4l/framework/builtin/spark/mllib/DocumentClassificationProcessorsSpec.scala
+++ b/test/org/nlp4l/framework/builtin/spark/mllib/DocumentClassificationProcessorsSpec.scala
@@ -43,7 +43,7 @@ class DocumentClassificationProcessorsSpec extends Specification with BeforeAfte
            |{
            | textField:   "text"
            | labelField:  "classification"
-           | workingDir:   "${TestSettings.TEST_OUT_DIR}"
+           | modelDir:   "${TestSettings.TEST_OUT_DIR}"
            | valuesFields:  ["classification", "text"]
            | analyzer : {
            |   tokenizer {
@@ -84,7 +84,7 @@ class DocumentClassificationProcessorsSpec extends Specification with BeforeAfte
       val config2 = ConfigFactory.parseString(
         s"""
            |{
-           | workingDir:   "${TestSettings.TEST_OUT_DIR}"
+           | modelDir:   "${TestSettings.TEST_OUT_DIR}"
            | algorithm:    "LogisticRegressionWithLBFGS"
            |}
         """.stripMargin)
@@ -101,7 +101,7 @@ class DocumentClassificationProcessorsSpec extends Specification with BeforeAfte
            | passThruFields: [
            |   "title"
            |   ]
-           | workingDir:   "${TestSettings.TEST_OUT_DIR}"
+           | modelDir:   "${TestSettings.TEST_OUT_DIR}"
            | analyzer : {
            |   tokenizer {
            |     factory : standard


### PR DESCRIPTION
Hi,

I've added the 'Keyphrase Extraction' features in our processor framework.

Since those processors uses the spark-MDLP-discretization package,
and I couldn't find the library compatible with our scala version,
I put their source in our app directory and build with our source.
I put the license descrption in NOTICE.TXT.

In addition, the following changes are included.

In the document classification processors,
the directory name was changed from workingDir to modelDir.

In the sample Csv processors,
in order to parse quoted text, quote mode (QuoteMode.MINIMAL) was added.

Changed the directory used in exmaples from /tmp to /opt/nlp4l.

Please take a look.

Thank you.
